### PR TITLE
A few fixes.

### DIFF
--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -130,11 +130,9 @@ class ReCaptcha
             $recaptchaResponse->success = true;
         } else {
             $recaptchaResponse->success = false;
-            $recaptchaResponse->errorCodes = $answers [error-codes];
+            $recaptchaResponse->errorCodes = $answers['error-codes'];
         }
 
         return $recaptchaResponse;
     }
 }
-
-?>


### PR DESCRIPTION
- No need for ending PHP tag.
- `$answers[error-codes]` is invalid `$answered['error-codes']` is correct.