### PR TITLE
Added support for curl transport, better support for PHP5 constructs

### DIFF
--- a/php/example-captcha.php
+++ b/php/example-captcha.php
@@ -35,7 +35,7 @@ $lang = "en";
 // The response object from reCAPTCHA
 $resp = null;
 
-$reCaptcha = new ReCaptcha($secret);
+$reCaptcha = new Google\ReCaptcha\Client($secret);
 
 // Was there a reCAPTCHA response?
 if ($_POST["g-recaptcha-response"]) {

--- a/php/example-captcha.php
+++ b/php/example-captcha.php
@@ -44,7 +44,7 @@ if ($_POST["g-recaptcha-response"]) {
             $_SERVER["REMOTE_ADDR"],
             $_POST["g-recaptcha-response"]
         );
-    } catch (ReCaptchaException $e) {
+    } catch (Google\RecCaptcha\Exception $e) {
         // handle exception
     }
 }

--- a/php/example-captcha.php
+++ b/php/example-captcha.php
@@ -32,26 +32,28 @@ $secret = "";
 // reCAPTCHA supported 40+ languages listed here: https://developers.google.com/recaptcha/docs/language
 $lang = "en";
 
-// The response from reCAPTCHA
+// The response object from reCAPTCHA
 $resp = null;
-// The error code from reCAPTCHA, if any
-$error = null;
 
 $reCaptcha = new ReCaptcha($secret);
 
 // Was there a reCAPTCHA response?
 if ($_POST["g-recaptcha-response"]) {
-    $resp = $reCaptcha->verifyResponse(
-        $_SERVER["REMOTE_ADDR"],
-        $_POST["g-recaptcha-response"]
-    );
+    try {
+        $resp = $reCaptcha->verifyResponse(
+            $_SERVER["REMOTE_ADDR"],
+            $_POST["g-recaptcha-response"]
+        );
+    } catch (ReCaptchaException $e) {
+        // handle exception
+    }
 }
 ?>
 <html>
   <head><title>reCAPTCHA Example</title></head>
   <body>
 <?php
-if ($resp != null && $resp->success) {
+if (is_object($resp) && $resp->success === true) {
     echo "You got it!";
 }
 ?>

--- a/php/example-proxy-captcha.php
+++ b/php/example-proxy-captcha.php
@@ -45,7 +45,7 @@ $proxy_opts = array(
                 CURLOPT_FAILONERROR => true,  // use only during tests
                 );
 
-$reCaptcha = new ReCaptcha($secret, $proxy_opts);
+$reCaptcha = new Google\ReCaptcha\Client($secret, $proxy_opts);
 
 // Was there a reCAPTCHA response?
 if ($_POST["g-recaptcha-response"]) {

--- a/php/example-proxy-captcha.php
+++ b/php/example-proxy-captcha.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Sample PHP code to use reCAPTCHA V2.
+ *
+ * @copyright Copyright (c) 2014, Google Inc.
+ * @link      http://www.google.com/recaptcha
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+require_once "recaptchalib.php";
+
+// Register API keys at https://www.google.com/recaptcha/admin
+$siteKey = "";
+$secret = "";
+// reCAPTCHA supported 40+ languages listed here: https://developers.google.com/recaptcha/docs/language
+$lang = "en";
+
+// The response object from reCAPTCHA
+$resp = null;
+
+// set up proxy parameters
+$proxy_opts = array(
+                CURLOPT_PROXY => "127.0.0.1",
+                CURLOPT_PROXYPORT => 80,
+                CURLOPT_PROXYTYPE => "HTTP",
+                CURLOPT_PROTOCOLS => "CURLPROTO_HTTP | CURLPROTO_HTTPS",
+                CURLOPT_PROXYUSERPWD => "user:password",
+                CURLOPT_FAILONERROR => true,  // use only during tests
+                );
+
+$reCaptcha = new ReCaptcha($secret, $proxy_opts);
+
+// Was there a reCAPTCHA response?
+if ($_POST["g-recaptcha-response"]) {
+    try {
+        $resp = $reCaptcha->verifyResponse(
+            $_SERVER["REMOTE_ADDR"],
+            $_POST["g-recaptcha-response"]
+        );
+    } catch (ReCaptchaException $e) {
+        // handle exception
+    }
+}
+?>
+<html>
+  <head><title>reCAPTCHA Example</title></head>
+  <body>
+<?php
+if (is_object($resp) && $resp->success === true) {
+    echo "You got it!";
+}
+?>
+    <form action="?" method="post">
+      <div class="g-recaptcha" data-sitekey="<?php echo $siteKey;?>"></div>
+      <script type="text/javascript"
+          src="https://www.google.com/recaptcha/api.js?hl=<?php echo $lang;?>">
+      </script>
+      <br/>
+      <input type="submit" value="submit" />
+    </form>
+  </body>
+</html>

--- a/php/example-proxy-captcha.php
+++ b/php/example-proxy-captcha.php
@@ -54,7 +54,7 @@ if ($_POST["g-recaptcha-response"]) {
             $_SERVER["REMOTE_ADDR"],
             $_POST["g-recaptcha-response"]
         );
-    } catch (ReCaptchaException $e) {
+    } catch (Google\RecCaptcha\Exception $e) {
         // handle exception
     }
 }

--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -52,7 +52,7 @@ class ReCaptcha
      *
      * @param string $secret shared secret between site and ReCAPTCHA server.
      */
-    function ReCaptcha($secret)
+    public function __construct($secret)
     {
         if ($secret == null || $secret == "") {
             die("To use reCAPTCHA you must get an API key from <a href='"

--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -43,11 +43,11 @@ class ReCaptchaException extends \Exception {}
 
 class ReCaptcha
 {
-    private static $_signupUrl = "https://www.google.com/recaptcha/admin";
+    private static $_signupUrl = 'https://www.google.com/recaptcha/admin';
     private static $_siteVerifyUrl =
-        "https://www.google.com/recaptcha/api/siteverify?";
+        'https://www.google.com/recaptcha/api/siteverify?';
     private $_secret;
-    private static $_version = "php_1.0";
+    private static $_version = 'php_1.0';
     private $_curl_opts;
 
     /**
@@ -57,9 +57,9 @@ class ReCaptcha
      */
     public function __construct($secret, array $curl_opts=array())
     {
-        if (is_null($secret) || $secret == "") {
-            throw new ReCaptchaException("To use reCAPTCHA you must get an API key from <a href='"
-                . self::$_signupUrl . "'>" . self::$_signupUrl . "</a>");
+        if (is_null($secret) || $secret == '') {
+            throw new ReCaptchaException('To use reCAPTCHA you must get an API key from <a href=\''
+                . self::$_signupUrl . '\'>' . self::$_signupUrl . '</a>');
         }
         $this->_secret=$secret;
         if (!empty($curl_opts)){
@@ -76,14 +76,12 @@ class ReCaptcha
      */
     private function _encodeQS($data)
     {
-        $req = "";
+        $req = array();
         foreach ($data as $key => $value) {
-            $req .= $key . '=' . urlencode(stripslashes($value)) . '&';
+            $req[] = $key . '=' . urlencode(stripslashes(trim($value)));
         }
 
-        // Cut the last '&'
-        $req=substr($req, 0, strlen($req)-1);
-        return $req;
+        return implode('&', $req);
     }
 
     /**
@@ -98,19 +96,19 @@ class ReCaptcha
     {
         $req = $this->_encodeQS($data);
         // prefer curl
-        if (function_exists("curl_version")) {
+        if (function_exists('curl_version')) {
             // default cURL options
             // modified from: http://stackoverflow.com/a/6595108
             $opts = array(
                         CURLOPT_HEADER         => false,
                         CURLOPT_RETURNTRANSFER => true,
                         CURLOPT_FOLLOWLOCATION => true,
-                        CURLOPT_USERAGENT      => "ReCaptcha ".self::$_version,
+                        CURLOPT_USERAGENT      => 'ReCaptcha '.self::$_version,
                         CURLOPT_AUTOREFERER    => true,
                         CURLOPT_CONNECTTIMEOUT => 60,
                         CURLOPT_TIMEOUT        => 60,
                         CURLOPT_MAXREDIRS      => 5,
-                        CURLOPT_ENCODING       => "",
+                        CURLOPT_ENCODING       => '',
                     );
             // check if we got overrides, or extra options (eg. proxy configuration)
             if (is_array($this->_curl_opts) && !empty($this->_curl_opts)) {
@@ -123,8 +121,8 @@ class ReCaptcha
             // handle a connection error
             $errno = curl_errno($conn);
             if ($errno !== 0) {
-                throw new ReCaptchaException("Fatal error while contacting reCAPTCHA. ".
-                    $errno . ": " . curl_error($conn) . "."
+                throw new ReCaptchaException('Fatal error while contacting reCAPTCHA. '.
+                    $errno . ': ' . curl_error($conn) . '.'
                 );
             }
             curl_close($conn);
@@ -165,15 +163,13 @@ class ReCaptcha
         $answers = json_decode($getResponse, true);
         $recaptchaResponse = new ReCaptchaResponse();
 
-        if (trim($answers ['success']) == true) {
+        if (trim($answers['success']) == true) {
             $recaptchaResponse->success = true;
         } else {
             $recaptchaResponse->success = false;
-            $recaptchaResponse->errorCodes = $answers [error-codes];
+            $recaptchaResponse->errorCodes = $answers['error-codes'];
         }
 
         return $recaptchaResponse;
     }
 }
-
-?>

--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -55,7 +55,7 @@ class ReCaptcha
      *
      * @param string $secret shared secret between site and ReCAPTCHA server.
      */
-    public function __construct($secret, array $curl_opts)
+    public function __construct($secret, array $curl_opts=array())
     {
         if ($secret == null || $secret == "") {
             throw new ReCaptchaException("To use reCAPTCHA you must get an API key from <a href='"
@@ -105,7 +105,7 @@ class ReCaptcha
                         CURLOPT_HEADER         => false,
                         CURLOPT_RETURNTRANSFER => true,
                         CURLOPT_FOLLOWLOCATION => true,
-                        CURLOPT_USERAGENT      => "ReCaptcha ".self::$version,
+                        CURLOPT_USERAGENT      => "ReCaptcha ".self::$_version,
                         CURLOPT_AUTOREFERER    => true,
                         CURLOPT_CONNECTTIMEOUT => 60,
                         CURLOPT_TIMEOUT        => 60,

--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -57,7 +57,7 @@ class ReCaptcha
      */
     public function __construct($secret, array $curl_opts=array())
     {
-        if ($secret == null || $secret == "") {
+        if (is_null($secret) || $secret == "") {
             throw new ReCaptchaException("To use reCAPTCHA you must get an API key from <a href='"
                 . self::$_signupUrl . "'>" . self::$_signupUrl . "</a>");
         }
@@ -128,7 +128,7 @@ class ReCaptcha
                 );
             }
             curl_close($conn);
-        } else {  // fallback 
+        } else {  // fallback
             $response = file_get_contents($path . $req);
         }
         return $response;
@@ -146,7 +146,7 @@ class ReCaptcha
     public function verifyResponse($remoteIp, $response)
     {
         // Discard empty solution submissions
-        if ($response == null || strlen($response) == 0) {
+        if (is_null($response) || strlen($response) == 0) {
             $recaptchaResponse = new ReCaptchaResponse();
             $recaptchaResponse->success = false;
             $recaptchaResponse->errorCodes = 'missing-input';


### PR DESCRIPTION
I have added support for curl, so the call to the reCAPTCHA service can work even when behind a proxy, apart from supporting timeouts, etc. There is an example that shows how to make use of that functionality.

Also made some changes to better support PHP5 syntax:

- Use the `__contruct()` method for the constructor
- Define and use an exception instead of just using `die()` to signify a fatal condition
- Removed the `$error` var because your response object already contains that information
- Refactored the class names y example code to use namespaces
