### PR TITLE
Update constructor to use __construct

### DIFF
--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -52,7 +52,7 @@ class ReCaptcha
      *
      * @param string $secret shared secret between site and ReCAPTCHA server.
      */
-    function ReCaptcha($secret)
+    function __construct($secret)
     {
         if ($secret == null || $secret == "") {
             die("To use reCAPTCHA you must get an API key from <a href='"


### PR DESCRIPTION
The __construct method has been available since PHP5 and makes the code more portable. Class-named constructors are no longer treated as a constructor in namespaced classes since PHP 5.3.3.