### PR TITLE
Fixing how the request is interpreted.

### DIFF
--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -126,11 +126,11 @@ class ReCaptcha
         $answers = json_decode($getResponse, true);
         $recaptchaResponse = new ReCaptchaResponse();
 
-        if (trim($answers ['success']) == true) {
-            $recaptchaResponse->success = true;
-        } else {
+        if ($answers ['success'] === false) {
             $recaptchaResponse->success = false;
-            $recaptchaResponse->errorCodes = $answers [error-codes];
+            $recaptchaResponse->errorCodes = $answers ['error-codes'];
+        } else {
+            $recaptchaResponse->success = true;
         }
 
         return $recaptchaResponse;


### PR DESCRIPTION
Fixing how the request is interpreted.

When google captcha api returns {'success': null, 'error-codes':null}, is when the captcha was verified successfully.

When the return value is {'success': false, 'error-codes': something} is when the verification fails.