### PR TITLE
Create API Keys Link is no more working

### DIFF
--- a/php/recaptchalib.php
+++ b/php/recaptchalib.php
@@ -4,7 +4,7 @@
  *    - Documentation and latest version
  *          https://developers.google.com/recaptcha/docs/php
  *    - Get a reCAPTCHA API Key
- *          https://www.google.com/recaptcha/admin/create
+ *          https://www.google.com/recaptcha/admin#list
  *    - Discussion group
  *          http://groups.google.com/group/recaptcha
  *


### PR DESCRIPTION
The Create API keys link is old, I've added the new link instead.