### PR TITLE
Allow manual install

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ Use [Composer](https://getcomposer.org/) to install the library. Either use
     }
 ```
 
+### Manual installation
+
+If you wish to install the library manually (i.e. without Composer),
+an autoloader is provided as `src/autoload.php`. You can require it in
+your script instead of the usual `vendor/autoload.php` created by
+Composer. For example,
+
+```php
+require('/path/to/recaptcha/autoload.php');
+
+$recaptcha = new \ReCaptcha\ReCaptcha($secret);
+// etc.
+```
+
 ## Usage
 
 First, register keys for your site at https://www.google.com/recaptcha/admin

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.4/phpunit.xsd" 
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.4/phpunit.xsd"
          colors="true"
-         verbose="true">
+         verbose="true"
+         bootstrap="src/autoload.php">
     <testsuites>
         <testsuite name="reCAPTCHA Test Suite">
             <directory>tests/ReCaptcha/</directory>

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,31 @@
+<?php
+
+/* An autoloader for ReCaptcha\Foo classes. This should be require()d
+ * by the user before attempting to instantiate any of the ReCaptcha
+ * classes.
+ */
+
+spl_autoload_register(function ($class) {
+    /* All of the classes have names like "ReCaptcha\Foo", so we need
+     * to replace the backslashes with frontslashes if we want the
+     * name to map directly to a location in the filesystem.
+     */
+    $class = str_replace('\\', '/', $class);
+
+    /* First, check under the current directory. It is important that
+     * we look here first, so that we don't waste time searching for
+     * test classes in the common case.
+     */
+    $path = dirname(__FILE__).'/'.$class.'.php';
+    if (file_exists($path)) {
+        require_once $path;
+    }
+
+    /* If we didn't find what we're looking for already, maybe it's
+     * a test class?
+     */
+    $path = dirname(__FILE__).'/../tests/'.$class.'.php';
+    if (file_exists($path)) {
+        require_once $path;
+    }
+});

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -6,6 +6,13 @@
  */
 
 spl_autoload_register(function ($class) {
+    if (substr($class, 0, 10) !== 'ReCaptcha\\') {
+      /* If the class does not lie under the "ReCaptcha" namespace,
+       * then we can exit immediately.
+       */
+      return;
+    }
+
     /* All of the classes have names like "ReCaptcha\Foo", so we need
      * to replace the backslashes with frontslashes if we want the
      * name to map directly to a location in the filesystem.

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -17,7 +17,7 @@ spl_autoload_register(function ($class) {
      * test classes in the common case.
      */
     $path = dirname(__FILE__).'/'.$class.'.php';
-    if (file_exists($path)) {
+    if (is_readable($path)) {
         require_once $path;
     }
 
@@ -25,7 +25,7 @@ spl_autoload_register(function ($class) {
      * a test class?
      */
     $path = dirname(__FILE__).'/../tests/'.$class.'.php';
-    if (file_exists($path)) {
+    if (is_readable($path)) {
         require_once $path;
     }
 });


### PR DESCRIPTION
Relying on Composer for the installation is causing us one big problem: the library can't be installed via our distribution's package manager. If you don't use Composer for the install, then Recaptcha doesn't work out-of-the-box: none of the class includes are in the files that use them. (This also crashes the test suite.)

The least-intrusive way to fix this (I could also have re-added the `require` statements?) was to supply a simple autoloader along with the library. This allows users to include the `src/autoload.php` even without Composer present on the target machine. Distributions can package `src/autoload.php` normally since it doesn't have to be generated on-the-fly. Finally, the test suite can bootstrap using it -- so now the test suite will run from a clean checkout.