### PR TITLE
Solved parameters arguments seperator

### DIFF
--- a/src/ReCaptcha/RequestParameters.php
+++ b/src/ReCaptcha/RequestParameters.php
@@ -98,6 +98,6 @@ class RequestParameters
      */
     public function toQueryString()
     {
-        return http_build_query($this->toArray());
+        return http_build_query($this->toArray(), '', '&');
     }
 }


### PR DESCRIPTION
Problem with generating param URI. On server with php [5.5.22-1] is generated with argument separator like html entity &amp;. It was problem because script returns error "missing-input-response". Now the separator is "&" - NOT html entity.