### PR TITLE
Add PSR-7 ServerRequest verify method

### DIFF
--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -26,6 +26,8 @@
 
 namespace ReCaptcha;
 
+use Psr\Http\Message\ServerRequestInterface;
+
 /**
  * reCAPTCHA client.
  */
@@ -93,5 +95,23 @@ class ReCaptcha
         $params = new RequestParameters($this->secret, $response, $remoteIp, self::VERSION);
         $rawResponse = $this->requestMethod->submit($params);
         return Response::fromJson($rawResponse);
+    }
+
+    /**
+     * Calls the reCAPTCHA siteverify API to verify whether the user passes
+     * CAPTCHA test using a PSR-7 ServerRequest object.
+     *
+     * @param ServerRequestInterface $request The request object
+     * @return Response Response from the service.
+     */
+    public function verifyRequest(ServerRequestInterface $request)
+    {
+        $body = $request->getParsedBody();
+        $server = $request->getServerParams();
+
+        $response = isset($body['g-recaptcha-response']) ? $body['g-recaptcha-response'] : '';
+        $remoteIp = isset($server['REMOTE_ADDR']) ? $server['REMOTE_ADDR'] : null;
+
+        return $this->verify($response, $remoteIp);
     }
 }


### PR DESCRIPTION
[PSR-7 HTTP Message Interface](http://www.php-fig.org/psr/psr-7/) is a common interface to represent http messages, so they can be shared between frameworks and libraries etc.

Using the ServerRequest interface can simplify handling the parameters. Example usage:

```
public function postForm(ServerRequestInterface $request)
{
    $recaptcha = new ReCaptcha\ReCaptcha('MY_SECRET);
    $response = $recaptcha->verifyRequest($request);
}
```

It isn't needed to actually require the interface, if people don't want to use it.
