### PR TITLE
add possibility to force IPv4 when using the Curl RequestMethod

### DIFF
--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -39,7 +39,7 @@ class ReCaptcha
 
     /**
      * Shared secret for the site.
-     * @var type string
+     * @var string
      */
     private $secret;
 
@@ -58,11 +58,11 @@ class ReCaptcha
     public function __construct($secret, RequestMethod $requestMethod = null)
     {
         if (empty($secret)) {
-            throw new \RuntimeException('No secret provided');
+            throw new \InvalidArgumentException('No secret provided');
         }
 
         if (!is_string($secret)) {
-            throw new \RuntimeException('The provided secret must be a string');
+            throw new \InvalidArgumentException('The provided secret must be a string');
         }
 
         $this->secret = $secret;

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -58,11 +58,11 @@ class ReCaptcha
     public function __construct($secret, RequestMethod $requestMethod = null)
     {
         if (empty($secret)) {
-            throw new \InvalidArgumentException('No secret provided');
+            throw new \RuntimeException('No secret provided');
         }
 
         if (!is_string($secret)) {
-            throw new \InvalidArgumentException('The provided secret must be a string');
+            throw new \RuntimeException('The provided secret must be a string');
         }
 
         $this->secret = $secret;

--- a/src/ReCaptcha/RequestMethod/Curl.php
+++ b/src/ReCaptcha/RequestMethod/Curl.php
@@ -17,6 +17,33 @@ class Curl implements RequestMethod
     const SITE_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
 
     /**
+     * @var bool
+     */
+    private $forceIpv4 = false;
+
+    /**
+     * @param array|\Traversable $options
+     */
+    public function __construct($options = array())
+    {
+        if (!$this->hasCurl()) {
+            throw new \RuntimeException('The cURL library must be installed');
+        }
+
+        if (!is_array($options) && !$options instanceof \Traversable) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    '%s expects an array or Traversable argument; received "%s"',
+                    __METHOD__,
+                    (is_object($options) ? get_class($options) : gettype($options))
+                )
+            );
+        }
+
+        $this->setOptions($options);
+    }
+
+    /**
      * Submit the cURL request with the specified parameters.
      *
      * @param RequestParameters $params Request parameters
@@ -37,11 +64,71 @@ class Curl implements RequestMethod
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => true
         );
+
+        if ($this->getForceIpv4()) {
+            $options[CURLOPT_IPRESOLVE] = CURL_IPRESOLVE_V4;
+        }
+
         curl_setopt_array($handle, $options);
 
         $response = curl_exec($handle);
         curl_close($handle);
 
         return $response;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getForceIpv4()
+    {
+        return $this->forceIpv4;
+    }
+
+    /**
+     * @param bool $forceIpv4
+     * @throws \RuntimeException
+     */
+    public function setForceIpv4($forceIpv4)
+    {
+        if ($forceIpv4 === true && !$this->hasCurloptIpresolve()) {
+            throw new \RuntimeException('The current cURL version does not support the "CURLOPT_IPRESOLVE" option.');
+        }
+        $this->forceIpv4 = $forceIpv4;
+    }
+
+    /**
+     * @param array|\Traversable $options
+     */
+    private function setOptions($options)
+    {
+        foreach ($options as $key => $value) {
+            $method = 'set' . str_replace('_', '', strtolower($key));
+            if (method_exists($this, $method)) {
+                $this->$method($value);
+            }
+        }
+    }
+
+    /**
+     * Check if the cURL library is available
+     *
+     * @return bool
+     */
+    private function hasCurl()
+    {
+        return (function_exists('curl_init')) ? true : false;
+    }
+
+    /**
+     * Check if the current cURL version is high enough
+     * to support the "CURLOPT_IPRESOLVE" option
+     *
+     * @return bool
+     */
+    private function hasCurloptIpresolve()
+    {
+        $version = curl_version();
+        return version_compare($version['version'], '7.10.8', '>=');
     }
 }


### PR DESCRIPTION
As requested in #44 this PR implements the possibility to force the Curl RequestMethod ho use IPv4:

```
$curl = new Curl();
$curl->setForceIpv4(true);
```

or
`$curl = new Curl(array('force_ipv4' => true));`

IPv4 for the other `RequestMethod`s will follow in separate PRs.
