### PR TITLE
CurlPost - allow configuration passed to constructor

### DIFF
--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -47,14 +47,16 @@ class CurlPost implements RequestMethod
      * @var Curl
      */
     private $curl;
+    private $curlOptions = [];
 
-    public function __construct(Curl $curl = null)
+    public function __construct(Curl $curl = null, array $curlOptions = [])
     {
         if (!is_null($curl)) {
             $this->curl = $curl;
         } else {
             $this->curl = new Curl();
         }
+        $this->curlOptions = [];
     }
 
     /**
@@ -79,6 +81,7 @@ class CurlPost implements RequestMethod
             CURLOPT_SSL_VERIFYPEER => true
         );
         $this->curl->setoptArray($handle, $options);
+        $this->curl->setoptArray($handle, $this->curlOptions);
 
         $response = $this->curl->exec($handle);
         $this->curl->close($handle);

--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -47,16 +47,16 @@ class CurlPost implements RequestMethod
      * @var Curl
      */
     private $curl;
-    private $curlOptions = [];
+    private $curlOptions = array();
 
-    public function __construct(Curl $curl = null, array $curlOptions = [])
+    public function __construct(Curl $curl = null, array $curlOptions = array())
     {
         if (!is_null($curl)) {
             $this->curl = $curl;
         } else {
             $this->curl = new Curl();
         }
-        $this->curlOptions = [];
+        $this->curlOptions = array();
     }
 
     /**

--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -80,8 +80,7 @@ class CurlPost implements RequestMethod
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => true
         );
-        $this->curl->setoptArray($handle, $options);
-        $this->curl->setoptArray($handle, $this->curlOptions);
+        $this->curl->setoptArray($handle, ($options + $this->curlOptions));;
 
         $response = $this->curl->exec($handle);
         $this->curl->close($handle);


### PR DESCRIPTION
Let's say you wanted to install ReCAPTCHA on, e.g. a Tor Hidden Service, and you didn't want to leak your hidden service's IP address. You could do this:

```php
$curl = new CurlPost(null, [
    CURLOPT_PROXY => 'http://127.0.0.1:9050/',
    CURLOPT_PROXYTYPE => CURLPROXY_SOCKS5
]);
```

And now your reCAPTCHA queries will be proxied over the Tor network.