### PR TITLE
Allow RequestMethod to return instance of Response

### DIFF
--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -91,7 +91,11 @@ class ReCaptcha
         }
 
         $params = new RequestParameters($this->secret, $response, $remoteIp, self::VERSION);
-        $rawResponse = $this->requestMethod->submit($params);
-        return Response::fromJson($rawResponse);
+        $response = $this->requestMethod->submit($params);
+        if ($response instanceof Response) {
+            return $response;
+        }
+
+        return Response::fromJson($response);
     }
 }

--- a/src/ReCaptcha/RequestMethod.php
+++ b/src/ReCaptcha/RequestMethod.php
@@ -36,7 +36,7 @@ interface RequestMethod
      * Submit the request with the specified parameters.
      *
      * @param RequestParameters $params Request parameters
-     * @return string Body of the reCAPTCHA response
+     * @return string|Response Body of the reCAPTCHA response or Response instance
      */
     public function submit(RequestParameters $params);
 }

--- a/tests/ReCaptcha/ReCaptchaTest.php
+++ b/tests/ReCaptcha/ReCaptchaTest.php
@@ -72,4 +72,17 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
         $response = $rc->verify('response');
         $this->assertTrue($response->isSuccess());
     }
+
+    public function testVerifyReturnsResponseInstance()
+    {
+        $method = $this->getMock('\\ReCaptcha\\RequestMethod', array('submit'));
+        $method->expects($this->once())
+            ->method('submit')
+            ->will($this->returnValue(new Response(true)))
+        ;
+
+        $rc = new ReCaptcha('secret', $method);
+        $response = $rc->verify('response');
+        $this->assertTrue($response->isSuccess());
+    }
 }


### PR DESCRIPTION
I would like that RequestMethod may return a Response instance to add informations.
By example, the cURL library give informations with the function [curl_getinfo](http://php.net/manual/function.curl-getinfo.php)().

These data are important to monitor the infrastructure.
