### PR TITLE
Add hostname attribute to Response object to allow server-side validation

### DIFF
--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -44,6 +44,12 @@ class Response
     private $errorCodes = array();
 
     /**
+     * The hostname of the site where the reCAPTCHA was solved.
+     * @var string
+     */
+    private $hostname = array();
+
+    /**
      * Build the response from the expected JSON returned by the service.
      *
      * @param string $json
@@ -57,15 +63,17 @@ class Response
             return new Response(false, array('invalid-json'));
         }
 
+        $hostname = isset($responseData['hostname']) ? $responseData['hostname'] : null;
+
         if (isset($responseData['success']) && $responseData['success'] == true) {
-            return new Response(true);
+            return new Response(true, [], $hostname);
         }
 
         if (isset($responseData['error-codes']) && is_array($responseData['error-codes'])) {
-            return new Response(false, $responseData['error-codes']);
+            return new Response(false, $responseData['error-codes'], $hostname);
         }
 
-        return new Response(false);
+        return new Response(false, array(), $hostname);
     }
 
     /**
@@ -73,11 +81,13 @@ class Response
      *
      * @param boolean $success
      * @param array $errorCodes
+     * @param string $hostname
      */
-    public function __construct($success, array $errorCodes = array())
+    public function __construct($success, array $errorCodes = array(), $hostname = null)
     {
         $this->success = $success;
         $this->errorCodes = $errorCodes;
+        $this->hostname = $hostname;
     }
 
     /**
@@ -98,5 +108,15 @@ class Response
     public function getErrorCodes()
     {
         return $this->errorCodes;
+    }
+
+    /**
+     * Get hostname.
+     *
+     * @return string
+     */
+    public function getHostname()
+    {
+      return $this->hostname;
     }
 }

--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -47,7 +47,7 @@ class Response
      * The hostname of the site where the reCAPTCHA was solved.
      * @var string
      */
-    private $hostname = array();
+    private $hostname;
 
     /**
      * Build the response from the expected JSON returned by the service.

--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -66,7 +66,7 @@ class Response
         $hostname = isset($responseData['hostname']) ? $responseData['hostname'] : null;
 
         if (isset($responseData['success']) && $responseData['success'] == true) {
-            return new Response(true, [], $hostname);
+            return new Response(true, array(), $hostname);
         }
 
         if (isset($responseData['error-codes']) && is_array($responseData['error-codes'])) {

--- a/tests/ReCaptcha/ResponseTest.php
+++ b/tests/ReCaptcha/ResponseTest.php
@@ -32,21 +32,26 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideJson
      */
-    public function testFromJson($json, $success, $errorCodes)
+    public function testFromJson($json, $success, $errorCodes, $hostname)
     {
         $response = Response::fromJson($json);
         $this->assertEquals($success, $response->isSuccess());
         $this->assertEquals($errorCodes, $response->getErrorCodes());
+        $this->assertEquals($hostname, $response->getHostname());
     }
 
     public function provideJson()
     {
         return array(
-            array('{"success": true}', true, array()),
-            array('{"success": false, "error-codes": ["test"]}', false, array('test')),
-            array('{"success": true, "error-codes": ["test"]}', true, array()),
-            array('{"success": false}', false, array()),
-            array('BAD JSON', false, array('invalid-json')),
+            array('{"success": true}', true, array(), null),
+            array('{"success": true, "hostname": "google.com"}', true, array(), 'google.com'),
+            array('{"success": false, "error-codes": ["test"]}', false, array('test'), null),
+            array('{"success": false, "error-codes": ["test"], "hostname": "google.com"}', false, array('test'), 'google.com'),
+            array('{"success": true, "error-codes": ["test"]}', true, array(), null),
+            array('{"success": true, "error-codes": ["test"], "hostname": "google.com"}', true, array(), 'google.com'),
+            array('{"success": false}', false, array(), null),
+            array('{"success": false, "hostname": "google.com"}', false, array(), 'google.com'),
+            array('BAD JSON', false, array('invalid-json'), null),
         );
     }
 
@@ -64,5 +69,13 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $errorCodes = array('test');
         $response = new Response(true, $errorCodes);
         $this->assertEquals($errorCodes, $response->getErrorCodes());
+    }
+
+    public function testGetHostname()
+    {
+      $hostname = 'google.com';
+      $errorCodes = array();
+      $response = new Response(true, $errorCodes, $hostname);
+      $this->assertEquals($hostname, $response->getHostname());
     }
 }


### PR DESCRIPTION
The **hostname** attribute can be used on server-side in order to check the domain name where the reCaptcha was solved to improve the security.

This verication is mandatory when the _domain name validation_ is turned off on Admin Console. See more: [https://developers.google.com/recaptcha/docs/domain_validation](https://developers.google.com/recaptcha/docs/domain_validation)

The `ResponseTest` was updated in order to check the new attribute.

This change does not break backwards compatibility. 
