### PR TITLE
PHPUnit forward compatibility layer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: php
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8.35|^5.7|^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -24,5 +24,8 @@
         "branch-alias": {
             "dev-master": "1.1.x-dev"
         }
+    },
+    "scripts": {
+        "test": "@php vendor/bin/phpunit --colors=always"
     }
 }

--- a/tests/ReCaptcha/ReCaptchaTest.php
+++ b/tests/ReCaptcha/ReCaptchaTest.php
@@ -26,7 +26,9 @@
 
 namespace ReCaptcha;
 
-class ReCaptchaTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ReCaptchaTest extends TestCase
 {
 
     /**
@@ -59,7 +61,10 @@ class ReCaptchaTest extends \PHPUnit_Framework_TestCase
 
     public function testVerifyReturnsResponse()
     {
-        $method = $this->getMock('\\ReCaptcha\\RequestMethod', array('submit'));
+        $method = $this->getMockBuilder(\ReCaptcha\RequestMethod::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('submit'))
+            ->getMock();
         $method->expects($this->once())
                 ->method('submit')
                 ->with($this->callback(function ($params) {

--- a/tests/ReCaptcha/RequestMethod/CurlPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/CurlPostTest.php
@@ -27,8 +27,9 @@
 namespace ReCaptcha\RequestMethod;
 
 use \ReCaptcha\RequestParameters;
+use PHPUnit\Framework\TestCase;
 
-class CurlPostTest extends \PHPUnit_Framework_TestCase
+class CurlPostTest extends TestCase
 {
 
     protected function setUp()
@@ -42,8 +43,10 @@ class CurlPostTest extends \PHPUnit_Framework_TestCase
 
     public function testSubmit()
     {
-        $curl = $this->getMock('\\ReCaptcha\\RequestMethod\\Curl',
-                array('init', 'setoptArray', 'exec', 'close'));
+        $curl = $this->getMockBuilder(\ReCaptcha\RequestMethod\Curl::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('init', 'setoptArray', 'exec', 'close'))
+            ->getMock();
         $curl->expects($this->once())
                 ->method('init')
                 ->willReturn(new \stdClass);

--- a/tests/ReCaptcha/RequestMethod/PostTest.php
+++ b/tests/ReCaptcha/RequestMethod/PostTest.php
@@ -27,8 +27,9 @@
 namespace ReCaptcha\RequestMethod;
 
 use ReCaptcha\RequestParameters;
+use PHPUnit\Framework\TestCase;
 
-class PostTest extends \PHPUnit_Framework_TestCase
+class PostTest extends TestCase
 {
     public static $assert = null;
     protected $parameters = null;

--- a/tests/ReCaptcha/RequestMethod/SocketPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/SocketPostTest.php
@@ -27,13 +27,16 @@
 namespace ReCaptcha\RequestMethod;
 
 use ReCaptcha\RequestParameters;
+use PHPUnit\Framework\TestCase;
 
-class SocketPostTest extends \PHPUnit_Framework_TestCase
+class SocketPostTest extends TestCase
 {
-
     public function testSubmitSuccess()
     {
-        $socket = $this->getMock('\\ReCaptcha\\RequestMethod\\Socket', array('fsockopen', 'fwrite', 'fgets', 'feof', 'fclose'));
+        $socket = $this->getMockBuilder(\ReCaptcha\RequestMethod\Socket::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('fsockopen', 'fwrite', 'fgets', 'feof', 'fclose'))
+            ->getMock();
         $socket->expects($this->once())
                 ->method('fsockopen')
                 ->willReturn(true);
@@ -56,7 +59,10 @@ class SocketPostTest extends \PHPUnit_Framework_TestCase
 
     public function testSubmitBadResponse()
     {
-        $socket = $this->getMock('\\ReCaptcha\\RequestMethod\\Socket', array('fsockopen', 'fwrite', 'fgets', 'feof', 'fclose'));
+        $socket = $this->getMockBuilder(\ReCaptcha\RequestMethod\Socket::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('fsockopen', 'fwrite', 'fgets', 'feof', 'fclose'))
+            ->getMock();
         $socket->expects($this->once())
                 ->method('fsockopen')
                 ->willReturn(true);
@@ -79,7 +85,10 @@ class SocketPostTest extends \PHPUnit_Framework_TestCase
 
     public function testSubmitBadRequest()
     {
-        $socket = $this->getMock('\\ReCaptcha\\RequestMethod\\Socket', array('fsockopen'));
+        $socket = $this->getMockBuilder(\ReCaptcha\RequestMethod\Socket::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('fsockopen'))
+            ->getMock();
         $socket->expects($this->once())
                 ->method('fsockopen')
                 ->willReturn(false);

--- a/tests/ReCaptcha/RequestParametersTest.php
+++ b/tests/ReCaptcha/RequestParametersTest.php
@@ -26,7 +26,9 @@
 
 namespace ReCaptcha;
 
-class RequestParametersTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class RequestParametersTest extends Testcase
 {
 
     public function provideValidData()

--- a/tests/ReCaptcha/ResponseTest.php
+++ b/tests/ReCaptcha/ResponseTest.php
@@ -26,7 +26,9 @@
 
 namespace ReCaptcha;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ResponseTest extends TestCase
 {
 
     /**


### PR DESCRIPTION
* Enabled PHPUnit v5 and v6. 
* Added `composer test` command
* Removed deprecated `getMock()` method