### PR TITLE
Show an explicit error when the connection fails

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,3 +54,11 @@ unit tested by passing in a mock. Take a look at
 [`RequestMethod\Curl`](./src/ReCaptcha/RequestMethod/Curl.php) with the matching
 [`RequestMethod/CurlPostTest`](./tests/ReCaptcha/RequestMethod/CurlPostTest.php)
 to see this pattern in action.
+
+### Error conventions
+
+The client returns the response as provided by the reCAPTCHA services augmented
+with additional error codes based on the client's checks. When adding a new
+[`RequestMethod`](./src/ReCaptcha/RequestMethod.php) ensure that it returns the
+`ReCaptcha::E_CONNECTION_FAILED` and `ReCaptcha::E_BAD_RESPONSE` where
+appropriate.

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -53,7 +53,7 @@ class ReCaptcha
      * Could not connect to service
      * @const string
      */
-    const E_BAD_CONNECTION = 'bad-connection';
+    const E_CONNECTION_FAILED = 'connection-failed';
 
     /**
      * Did not receive a 200 from the service

--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -87,6 +87,10 @@ class CurlPost implements RequestMethod
         $response = $this->curl->exec($handle);
         $this->curl->close($handle);
 
-        return $response;
+        if ($response !== false) {
+            return $response;
+        }
+
+        return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
     }
 }

--- a/src/ReCaptcha/RequestMethod/Post.php
+++ b/src/ReCaptcha/RequestMethod/Post.php
@@ -69,6 +69,12 @@ class Post implements RequestMethod
             ),
         );
         $context = stream_context_create($options);
-        return file_get_contents($this->siteVerifyUrl, false, $context);
+        $response = file_get_contents($this->siteVerifyUrl, false, $context);
+
+        if ($response !== false) {
+            return $response;
+        }
+
+        return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
     }
 }

--- a/src/ReCaptcha/RequestMethod/SocketPost.php
+++ b/src/ReCaptcha/RequestMethod/SocketPost.php
@@ -68,7 +68,7 @@ class SocketPost implements RequestMethod
         $urlParsed = parse_url($this->siteVerifyUrl);
 
         if (false === $this->socket->fsockopen('ssl://' . $urlParsed['host'], 443, $errno, $errstr, 30)) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_CONNECTION.'"]}';
+            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
         }
 
         $content = $params->toQueryString();

--- a/tests/ReCaptcha/RequestMethod/CurlPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/CurlPostTest.php
@@ -26,6 +26,7 @@
 
 namespace ReCaptcha\RequestMethod;
 
+use \ReCaptcha\ReCaptcha;
 use \ReCaptcha\RequestParameters;
 use PHPUnit\Framework\TestCase;
 
@@ -87,5 +88,28 @@ class CurlPostTest extends TestCase
         $pc = new CurlPost($curl, $url);
         $response = $pc->submit(new RequestParameters("secret", "response"));
         $this->assertEquals('RESPONSEBODY', $response);
+    }
+
+    public function testConnectionFailureReturnsError()
+    {
+        $curl = $this->getMockBuilder(\ReCaptcha\RequestMethod\Curl::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('init', 'setoptArray', 'exec', 'close'))
+            ->getMock();
+        $curl->expects($this->once())
+                ->method('init')
+                ->willReturn(new \stdClass);
+        $curl->expects($this->once())
+                ->method('setoptArray')
+                ->willReturn(true);
+        $curl->expects($this->once())
+                ->method('exec')
+                ->willReturn(false);
+        $curl->expects($this->once())
+                ->method('close');
+
+        $pc = new CurlPost($curl);
+        $response = $pc->submit(new RequestParameters("secret", "response"));
+        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
     }
 }

--- a/tests/ReCaptcha/RequestMethod/PostTest.php
+++ b/tests/ReCaptcha/RequestMethod/PostTest.php
@@ -26,6 +26,7 @@
 
 namespace ReCaptcha\RequestMethod;
 
+use \ReCaptcha\ReCaptcha;
 use ReCaptcha\RequestParameters;
 use PHPUnit\Framework\TestCase;
 
@@ -37,7 +38,7 @@ class PostTest extends TestCase
 
     public function setUp()
     {
-        $this->parameters = new RequestParameters("secret", "response", "remoteip", "version");
+        $this->parameters = new RequestParameters('secret', 'response', 'remoteip', 'version');
     }
 
     public function tearDown()
@@ -48,17 +49,17 @@ class PostTest extends TestCase
     public function testHTTPContextOptions()
     {
         $req = new Post();
-        self::$assert = array($this, "httpContextOptionsCallback");
+        self::$assert = array($this, 'httpContextOptionsCallback');
         $req->submit($this->parameters);
-        $this->assertEquals(1, $this->runcount, "The assertion was ran");
+        $this->assertEquals(1, $this->runcount, 'The assertion was ran');
     }
 
     public function testSSLContextOptions()
     {
         $req = new Post();
-        self::$assert = array($this, "sslContextOptionsCallback");
+        self::$assert = array($this, 'sslContextOptionsCallback');
         $req->submit($this->parameters);
-        $this->assertEquals(1, $this->runcount, "The assertion was ran");
+        $this->assertEquals(1, $this->runcount, 'The assertion was ran');
     }
 
     public function testOverrideVerifyUrl()
@@ -66,9 +67,20 @@ class PostTest extends TestCase
         $req = new Post('https://over.ride/some/path');
         self::$assert = array($this, 'overrideUrlOptions');
         $req->submit($this->parameters);
-        $this->assertEquals(1, $this->runcount, "The assertion was ran");
+        $this->assertEquals(1, $this->runcount, 'The assertion was ran');
     }
 
+    public function testConnectionFailureReturnsError()
+    {
+        $req = new Post('https://bad.connection/');
+        self::$assert = array($this, 'connectionFailureResponse');
+        $response = $req->submit($this->parameters);
+        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
+    }
+
+    public function connectionFailureResponse() {
+        return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
+    }
     public function overrideUrlOptions(array $args)
     {
         $this->runcount++;
@@ -84,14 +96,14 @@ class PostTest extends TestCase
         $this->assertArrayHasKey('http', $options);
 
         $this->assertArrayHasKey('method', $options['http']);
-        $this->assertEquals("POST", $options['http']['method']);
+        $this->assertEquals('POST', $options['http']['method']);
 
         $this->assertArrayHasKey('content', $options['http']);
         $this->assertEquals($this->parameters->toQueryString(), $options['http']['content']);
 
         $this->assertArrayHasKey('header', $options['http']);
         $headers = array(
-            "Content-type: application/x-www-form-urlencoded",
+            'Content-type: application/x-www-form-urlencoded',
         );
         foreach ($headers as $header) {
             $this->assertContains($header, $options['http']['header']);
@@ -112,9 +124,9 @@ class PostTest extends TestCase
     protected function assertCommonOptions(array $args)
     {
         $this->assertCount(3, $args);
-        $this->assertStringStartsWith("https://www.google.com/", $args[0]);
+        $this->assertStringStartsWith('https://www.google.com/', $args[0]);
         $this->assertFalse($args[1]);
-        $this->assertTrue(is_resource($args[2]), "The context options should be a resource");
+        $this->assertTrue(is_resource($args[2]), 'The context options should be a resource');
     }
 }
 

--- a/tests/ReCaptcha/RequestMethod/PostTest.php
+++ b/tests/ReCaptcha/RequestMethod/PostTest.php
@@ -78,7 +78,8 @@ class PostTest extends TestCase
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
     }
 
-    public function connectionFailureResponse() {
+    public function connectionFailureResponse()
+    {
         return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
     }
     public function overrideUrlOptions(array $args)

--- a/tests/ReCaptcha/RequestMethod/PostTest.php
+++ b/tests/ReCaptcha/RequestMethod/PostTest.php
@@ -80,7 +80,7 @@ class PostTest extends TestCase
 
     public function connectionFailureResponse()
     {
-        return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
+        return false;
     }
     public function overrideUrlOptions(array $args)
     {

--- a/tests/ReCaptcha/RequestMethod/SocketPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/SocketPostTest.php
@@ -123,6 +123,6 @@ class SocketPostTest extends TestCase
                 ->willReturn(false);
         $ps = new SocketPost($socket);
         $response = $ps->submit(new RequestParameters("secret", "response", "remoteip", "version"));
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_CONNECTION.'"]}', $response);
+        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
     }
 }

--- a/tests/ReCaptcha/RequestMethod/SocketPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/SocketPostTest.php
@@ -112,7 +112,7 @@ class SocketPostTest extends TestCase
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
     }
 
-    public function testSubmitBadRequest()
+    public function testConnectionFailureReturnsError()
     {
         $socket = $this->getMockBuilder(\ReCaptcha\RequestMethod\Socket::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
Currently any issues with the connection will just result in an `invalid-json` error which is misleading. This change updates the request methods to return `connection-failed` instead.