### PR TITLE
Add PHP 7.4 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,19 @@
-dist: trusty
+dist: xenial
 
 language: php
 
-sudo: false
-
 php:
-  - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
+
+matrix:
+  include:
+    - php: 5.5
+      dist: trusty
 
 before_script:
   - composer install


### PR DESCRIPTION
- Add PHP 7.4 to Travis
- Bump `dist` to `xenial`
- Remove `sudo: false` because this setting was deprecated (https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration)