### PR TITLE
Update recaptcha-v2-checkbox.php

### DIFF
--- a/examples/recaptcha-v2-checkbox.php
+++ b/examples/recaptcha-v2-checkbox.php
@@ -77,7 +77,7 @@ if ($siteKey === '' || $secret === ''):
     <h2>Add your keys</h2>
     <p>If you do not have keys already then visit <kbd> <a href = "https://www.google.com/recaptcha/admin">https://www.google.com/recaptcha/admin</a></kbd> to generate them. Edit this file and set the respective keys in the <kbd>config.php</kbd> file or directly to <kbd>$siteKey</kbd> and <kbd>$secret</kbd>. Reload the page after this.</p>
     <?php
-elseif (isset($_POST['g-recaptcha-response'])):
+elseif (!empty($_POST['g-recaptcha-response'])):
     // The POST data here is unfiltered because this is an example.
     // In production, *always* sanitise and validate your input'
     ?>


### PR DESCRIPTION
Checking `isset` on $_POST['g-recaptcha-response'] always passed for me locally on PHP 8.0.14. Changing to `!empty` actually failed when recaptcha was unchecked, which is the expected behavior. Don't know if this works for everyone across the board.