### PR TITLE
Add needed attribute for ReCaptcha to work with PHP8.2

### DIFF
--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -37,6 +37,7 @@ namespace ReCaptcha;
 /**
  * reCAPTCHA client.
  */
+#[\AllowDynamicProperties]
 class ReCaptcha
 {
     /**


### PR DESCRIPTION
When switching to PHP8.2 I have the following issue with ReCaptcha/ReCaptcha

<img width="723" alt="Capture d’écran 2022-12-28 à 15 34 19" src="https://user-images.githubusercontent.com/6584067/209827869-fea73437-959a-4b89-a7c8-c23df1dd797a.png">

It's because this class is full of dynamic properties, which is not accepted by PHP8.2 without this attribute.