### PR TITLE
Php84

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" colors="true" bootstrap="src/autoload.php" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+	colors="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	bootstrap="src/autoload.php"
+	cacheDirectory=".phpunit.cache"
+	>
   <coverage>
     <include>
       <directory suffix=".php">src/ReCaptcha/</directory>

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -136,7 +136,7 @@ class ReCaptcha
      * @param RequestMethod $requestMethod method used to send the request. Defaults to POST.
      * @throws \RuntimeException if $secret is invalid
      */
-    public function __construct($secret, RequestMethod $requestMethod = null)
+    public function __construct($secret, ?RequestMethod $requestMethod = null)
     {
         if (empty($secret)) {
             throw new \RuntimeException('No secret provided');
@@ -158,7 +158,7 @@ class ReCaptcha
      * @param string $remoteIp The end user's IP address.
      * @return Response Response from the service.
      */
-    public function verify($response, $remoteIp = null)
+    public function verify(string $response, ?string $remoteIp = null)
     {
         // Discard empty solution submissions
         if (empty($response)) {
@@ -217,7 +217,7 @@ class ReCaptcha
      * @param string $hostname Expected hostname
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setExpectedHostname($hostname)
+    public function setExpectedHostname(string $hostname)
     {
         $this->hostname = $hostname;
         return $this;
@@ -229,7 +229,7 @@ class ReCaptcha
      * @param string $apkPackageName Expected APK package name
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setExpectedApkPackageName($apkPackageName)
+    public function setExpectedApkPackageName(string $apkPackageName)
     {
         $this->apkPackageName = $apkPackageName;
         return $this;
@@ -242,7 +242,7 @@ class ReCaptcha
      * @param string $action Expected action
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setExpectedAction($action)
+    public function setExpectedAction(string $action)
     {
         $this->action = $action;
         return $this;
@@ -255,7 +255,7 @@ class ReCaptcha
      * @param float $threshold Expected threshold
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setScoreThreshold($threshold)
+    public function setScoreThreshold(float $threshold)
     {
         $this->threshold = floatval($threshold);
         return $this;
@@ -267,7 +267,7 @@ class ReCaptcha
      * @param int $timeoutSeconds Expected hostname
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setChallengeTimeout($timeoutSeconds)
+    public function setChallengeTimeout(int $timeoutSeconds)
     {
         $this->timeoutSeconds = $timeoutSeconds;
         return $this;

--- a/src/ReCaptcha/RequestMethod/Curl.php
+++ b/src/ReCaptcha/RequestMethod/Curl.php
@@ -44,7 +44,7 @@ class Curl
      * @param string $url
      * @return resource cURL handle
      */
-    public function init($url = null)
+    public function init(?string $url = null)
     {
         return curl_init($url);
     }

--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -63,7 +63,7 @@ class CurlPost implements RequestMethod
      * @param Curl $curl Curl resource
      * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(Curl $curl = null, $siteVerifyUrl = null)
+    public function __construct(?Curl $curl = null, ?string $siteVerifyUrl = null)
     {
         $this->curl = (is_null($curl)) ? new Curl() : $curl;
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;

--- a/src/ReCaptcha/RequestMethod/Post.php
+++ b/src/ReCaptcha/RequestMethod/Post.php
@@ -54,7 +54,7 @@ class Post implements RequestMethod
      *
      * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct($siteVerifyUrl = null)
+    public function __construct(?string $siteVerifyUrl = null)
     {
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
     }

--- a/src/ReCaptcha/RequestMethod/Socket.php
+++ b/src/ReCaptcha/RequestMethod/Socket.php
@@ -53,7 +53,7 @@ class Socket
      * @param float $timeout
      * @return resource
      */
-    public function fsockopen($hostname, $port = -1, &$errno = 0, &$errstr = '', $timeout = null)
+    public function fsockopen(string $hostname, int $port = -1, int &$errno = 0, string &$errstr = '', ?float $timeout = null)
     {
         $this->handle = fsockopen($hostname, $port, $errno, $errstr, (is_null($timeout) ? ini_get("default_socket_timeout") : $timeout));
 
@@ -71,7 +71,7 @@ class Socket
      * @param int $length
      * @return int | bool
      */
-    public function fwrite($string, $length = null)
+    public function fwrite(string $string, ?int $length = null)
     {
         return fwrite($this->handle, $string, (is_null($length) ? strlen($string) : $length));
     }
@@ -83,7 +83,7 @@ class Socket
      * @param int $length
      * @return string
      */
-    public function fgets($length = null)
+    public function fgets(?int $length = null)
     {
         return fgets($this->handle, $length);
     }

--- a/src/ReCaptcha/RequestMethod/SocketPost.php
+++ b/src/ReCaptcha/RequestMethod/SocketPost.php
@@ -59,7 +59,7 @@ class SocketPost implements RequestMethod
      * @param \ReCaptcha\RequestMethod\Socket $socket optional socket, injectable for testing
      * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(Socket $socket = null, $siteVerifyUrl = null)
+    public function __construct(?Socket $socket = null, ?string $siteVerifyUrl = null)
     {
         $this->socket = (is_null($socket)) ? new Socket() : $socket;
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;

--- a/src/ReCaptcha/RequestParameters.php
+++ b/src/ReCaptcha/RequestParameters.php
@@ -71,7 +71,7 @@ class RequestParameters
      * @param string $remoteIp User's IP address.
      * @param string $version Version of this client library.
      */
-    public function __construct($secret, $response, $remoteIp = null, $version = null)
+    public function __construct(string $secret, string $response, ?string $remoteIp = null, ?string $version = null)
     {
         $this->secret = $secret;
         $this->response = $response;

--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -87,7 +87,7 @@ class Response
      * @param string $json
      * @return \ReCaptcha\Response
      */
-    public static function fromJson($json)
+    public static function fromJson(string $json)
     {
         $responseData = json_decode($json, true);
 
@@ -123,7 +123,7 @@ class Response
      * @param string $action
      * @param array $errorCodes
      */
-    public function __construct($success, array $errorCodes = array(), $hostname = '', $challengeTs = '', $apkPackageName = '', $score = null, $action = '')
+    public function __construct(bool $success, array $errorCodes = [], string $hostname = '', string $challengeTs = '', string $apkPackageName = '', ?float $score = null, string $action = '')
     {
         $this->success = $success;
         $this->hostname = $hostname;


### PR DESCRIPTION
* Added configuration options to PHPUnit to show depreciations and warning messages.
* Removed PHP 8.4 depreciations for functions that set parameters to null.
* Added types to all function parameters based on DocBlock types.

I could not run the composer scripts on my Windows machine, but PHPUnit runs in the normal way. I did not run PHPCSFixer.

No logic changes were made.
