### PR TITLE
🧹 Centralize error JSON generation in Response class

### DIFF
--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -42,6 +42,7 @@ namespace ReCaptcha\RequestMethod;
 use ReCaptcha\ReCaptcha;
 use ReCaptcha\RequestMethod;
 use ReCaptcha\RequestParameters;
+use ReCaptcha\Response;
 
 /**
  * Sends cURL request to the reCAPTCHA service.
@@ -98,7 +99,7 @@ class CurlPost implements RequestMethod
                 return $response;
             }
 
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
+            return Response::errorJson(ReCaptcha::E_CONNECTION_FAILED);
         } finally {
             curl_close($handle);
         }

--- a/src/ReCaptcha/RequestMethod/Post.php
+++ b/src/ReCaptcha/RequestMethod/Post.php
@@ -42,6 +42,7 @@ namespace ReCaptcha\RequestMethod;
 use ReCaptcha\ReCaptcha;
 use ReCaptcha\RequestMethod;
 use ReCaptcha\RequestParameters;
+use ReCaptcha\Response;
 
 /**
  * Sends POST requests to the reCAPTCHA service.
@@ -87,6 +88,6 @@ class Post implements RequestMethod
             return $response;
         }
 
-        return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
+        return Response::errorJson(ReCaptcha::E_CONNECTION_FAILED);
     }
 }

--- a/src/ReCaptcha/RequestMethod/SocketPost.php
+++ b/src/ReCaptcha/RequestMethod/SocketPost.php
@@ -42,6 +42,7 @@ namespace ReCaptcha\RequestMethod;
 use ReCaptcha\ReCaptcha;
 use ReCaptcha\RequestMethod;
 use ReCaptcha\RequestParameters;
+use ReCaptcha\Response;
 
 /**
  * Sends a POST request to the reCAPTCHA service, but makes use of fsockopen()
@@ -76,17 +77,17 @@ class SocketPost implements RequestMethod
         $urlParsed = parse_url($this->siteVerifyUrl);
 
         if (false === $urlParsed || !isset($urlParsed['host']) || !isset($urlParsed['path'])) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
+            return Response::errorJson(ReCaptcha::E_CONNECTION_FAILED);
         }
 
         $handle = fsockopen('ssl://'.$urlParsed['host'], 443, $errno, $errstr, 30);
 
         if (false === $handle || 0 !== $errno || '' !== $errstr) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
+            return Response::errorJson(ReCaptcha::E_CONNECTION_FAILED);
         }
 
         if (false === stream_set_timeout($handle, 60)) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
+            return Response::errorJson(ReCaptcha::E_CONNECTION_FAILED);
         }
 
         $content = $params->toQueryString();
@@ -108,13 +109,13 @@ class SocketPost implements RequestMethod
         }
 
         if (1 !== preg_match('#^HTTP/1\.[01] 200 OK#', $response)) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}';
+            return Response::errorJson(ReCaptcha::E_BAD_RESPONSE);
         }
 
         $parts = preg_split("#\n\\s*\n#Uis", $response);
 
         if (!is_array($parts) || !isset($parts[1])) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}';
+            return Response::errorJson(ReCaptcha::E_BAD_RESPONSE);
         }
 
         return $parts[1];

--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -98,6 +98,18 @@ class Response
     }
 
     /**
+     * Build an error response JSON string with the specified error code.
+     *
+     * @param string $errorCode The error code to return
+     *
+     * @return string The JSON string
+     */
+    public static function errorJson(string $errorCode): string
+    {
+        return json_encode(['success' => false, 'error-codes' => [$errorCode]]);
+    }
+
+    /**
      * Build the response from the expected JSON returned by the service.
      */
     public static function fromJson(string $json): Response


### PR DESCRIPTION
🎯 **What:** Duplicated hardcoded JSON error strings for `E_CONNECTION_FAILED` and `E_BAD_RESPONSE` were removed from multiple `RequestMethod` implementations and replaced with a central `Response::errorJson()` method.
💡 **Why:** This reduces code duplication and ensures consistent error response formatting across all request methods. It also makes it easier to change the error response format in the future if needed.
✅ **Verification:** A standalone PHP verification script was used to ensure that `Response::errorJson()` generates the correct JSON and that it is properly parsed by `Response::fromJson()`.
✨ **Result:** Improved code maintainability and reduced duplication by centralizing error formatting logic.

---
*PR created automatically by Jules for task [13806251128490405200](https://jules.google.com/task/13806251128490405200) started by @rowan-m*