### PR TITLE
🧪 [testing improvement] Add test for case-insensitive hostname matching

### DIFF
--- a/tests/ReCaptcha/ReCaptchaTest.php
+++ b/tests/ReCaptcha/ReCaptchaTest.php
@@ -178,6 +178,19 @@ class ReCaptchaTest extends TestCase
         $this->assertEquals([ReCaptcha::E_HOSTNAME_MISMATCH], $response->getErrorCodes());
     }
 
+    public function testVerifyHostnameMatchCaseInsensitive(): void
+    {
+        $method = $this->getMockRequestMethod('{"success": true, "hostname": "host.name"}');
+        $rc = new ReCaptcha('secret', $method);
+        $response = $rc->setExpectedHostname('HOST.NAME')->verify('response');
+        $this->assertTrue($response->isSuccess());
+
+        $method = $this->getMockRequestMethod('{"success": true, "hostname": "HOST.NAME"}');
+        $rc = new ReCaptcha('secret', $method);
+        $response = $rc->setExpectedHostname('host.name')->verify('response');
+        $this->assertTrue($response->isSuccess());
+    }
+
     public function testVerifyApkPackageNameMatch(): void
     {
         $method = $this->getMockRequestMethod('{"success": true, "apk_package_name": "apk.name"}');


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the lack of a test case for case-insensitive hostname verification in the `ReCaptcha` class.
📊 **Coverage:** The new test `testVerifyHostnameMatchCaseInsensitive` covers scenarios where the expected hostname and the response hostname have different casing (e.g., 'HOST.NAME' vs 'host.name' and vice versa).
✨ **Result:** This improvement ensures that the case-insensitive matching behavior is preserved during future refactoring and increases the reliability of the hostname validation logic.

---
*PR created automatically by Jules for task [5612976521281188627](https://jules.google.com/task/5612976521281188627) started by @rowan-m*