### PR TITLE
fix : prevent reflected XSS by encoding var_export() output

### DIFF
--- a/examples/recaptcha-request-curl.php
+++ b/examples/recaptcha-request-curl.php
@@ -87,7 +87,7 @@ if ('' === $siteKey || '' === $secret) {
     // In production, *always* sanitise and validate your input'
     ?>
         <h2><kbd>POST</kbd> data</h2>
-        <kbd><pre><?php var_export($_POST); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
     // If the form submission includes the "g-captcha-response" field
     // Create an instance of the service using your secret and the CurlPost request method.
@@ -111,7 +111,7 @@ if ('' === $siteKey || '' === $secret) {
         // If the response is a success, that's it!
         ?>
         <h2>Success!</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>That's it. Everything is working. Go integrate this into your real project.</p>
         <p><a href="/recaptcha-request-curl.php"><span aria-hidden="true">⤴️</span> Try again</a></p>
         <?php
@@ -119,7 +119,7 @@ if ('' === $siteKey || '' === $secret) {
         // If it's not successful, then one or more error codes will be returned.
         ?>
         <h2>Something went wrong</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>Check the error code reference at <kbd><a href="https://developers.google.com/recaptcha/docs/verify#error-code-reference">https://developers.google.com/recaptcha/docs/verify#error-code-reference</a></kbd>.
         <p><strong>Note:</strong> Error code <kbd>missing-input-response</kbd> may mean the user just didn't complete the reCAPTCHA.</p>
         <p><a href="/recaptcha-request-curl.php"><span aria-hidden="true">⤴️</span> Try again</a></p>

--- a/examples/recaptcha-request-post.php
+++ b/examples/recaptcha-request-post.php
@@ -86,7 +86,7 @@ if ('' === $siteKey || '' === $secret) {
     // In production, *always* sanitise and validate your input'
     ?>
         <h2><kbd>POST</kbd> data</h2>
-        <kbd><pre><?php var_export($_POST); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
     // If the form submission includes the "g-captcha-response" field
     // Create an instance of the service using your secret and the Post request method.
@@ -110,7 +110,7 @@ if ('' === $siteKey || '' === $secret) {
         // If the response is a success, that's it!
         ?>
         <h2>Success!</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>That's it. Everything is working. Go integrate this into your real project.</p>
         <p><a href="/recaptcha-request-post.php"><span aria-hidden="true">⤴️</span> Try again</a></p>
         <?php
@@ -118,7 +118,7 @@ if ('' === $siteKey || '' === $secret) {
         // If it's not successful, then one or more error codes will be returned.
         ?>
         <h2>Something went wrong</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>Check the error code reference at <kbd><a href="https://developers.google.com/recaptcha/docs/verify#error-code-reference">https://developers.google.com/recaptcha/docs/verify#error-code-reference</a></kbd>.
         <p><strong>Note:</strong> Error code <kbd>missing-input-response</kbd> may mean the user just didn't complete the reCAPTCHA.</p>
         <p><a href="/recaptcha-request-post.php"><span aria-hidden="true">⤴️</span> Try again</a></p>

--- a/examples/recaptcha-request-socket.php
+++ b/examples/recaptcha-request-socket.php
@@ -85,7 +85,7 @@ if ('' === $siteKey || '' === $secret) {
     // In production, *always* sanitise and validate your input'
     ?>
         <h2><kbd>POST</kbd> data</h2>
-        <kbd><pre><?php var_export($_POST); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
     // If the form submission includes the "g-captcha-response" field
     // Create an instance of the service using your secret and the SocketPost request method.
@@ -109,7 +109,7 @@ if ('' === $siteKey || '' === $secret) {
         // If the response is a success, that's it!
         ?>
         <h2>Success!</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>That's it. Everything is working. Go integrate this into your real project.</p>
         <p><a href="/recaptcha-request-socket.php"><span aria-hidden="true">⤴️</span> Try again</a></p>
         <?php
@@ -117,7 +117,7 @@ if ('' === $siteKey || '' === $secret) {
         // If it's not successful, then one or more error codes will be returned.
         ?>
         <h2>Something went wrong</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>Check the error code reference at <kbd><a href="https://developers.google.com/recaptcha/docs/verify#error-code-reference">https://developers.google.com/recaptcha/docs/verify#error-code-reference</a></kbd>.
         <p><strong>Note:</strong> Error code <kbd>missing-input-response</kbd> may mean the user just didn't complete the reCAPTCHA.</p>
         <p><a href="/recaptcha-request-socket.php"><span aria-hidden="true">⤴️</span> Try again</a></p>

--- a/examples/recaptcha-v2-checkbox-explicit.php
+++ b/examples/recaptcha-v2-checkbox-explicit.php
@@ -84,7 +84,7 @@ if ('' === $siteKey || '' === $secret) {
     // In production, *always* sanitise and validate your input'
     ?>
         <h2><kbd>POST</kbd> data</h2>
-        <kbd><pre><?php var_export($_POST); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
     // If the form submission includes the "g-captcha-response" field
     // Create an instance of the service using your secret
@@ -113,7 +113,7 @@ if ('' === $siteKey || '' === $secret) {
         // If the response is a success, that's it!
         ?>
         <h2>Success!</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>That's it. Everything is working. Go integrate this into your real project.</p>
         <p><a href="/recaptcha-v2-checkbox-explicit.php"><span aria-hidden="true">⤴️</span> Try again</a></p>
         <?php
@@ -121,7 +121,7 @@ if ('' === $siteKey || '' === $secret) {
         // If it's not successful, then one or more error codes will be returned.
         ?>
         <h2>Something went wrong</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>Check the error code reference at <kbd><a href="https://developers.google.com/recaptcha/docs/verify#error-code-reference">https://developers.google.com/recaptcha/docs/verify#error-code-reference</a></kbd>.
         <p><strong>Note:</strong> Error code <kbd>missing-input-response</kbd> may mean the user just didn't complete the reCAPTCHA.</p>
         <p><a href="/recaptcha-v2-checkbox-explicit.php"><span aria-hidden="true">⤴️</span> Try again</a></p>

--- a/examples/recaptcha-v2-checkbox.php
+++ b/examples/recaptcha-v2-checkbox.php
@@ -84,7 +84,7 @@ if ('' === $siteKey || '' === $secret) {
     // In production, *always* sanitise and validate your input'
     ?>
         <h2><kbd>POST</kbd> data</h2>
-        <kbd><pre><?php var_export($_POST); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
     // If the form submission includes the "g-captcha-response" field
     // Create an instance of the service using your secret
@@ -113,7 +113,7 @@ if ('' === $siteKey || '' === $secret) {
         // If the response is a success, that's it!
         ?>
         <h2>Success!</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>That's it. Everything is working. Go integrate this into your real project.</p>
         <p><a href="/recaptcha-v2-checkbox.php"><span aria-hidden="true">⤴️</span> Try again</a></p>
         <?php
@@ -121,7 +121,7 @@ if ('' === $siteKey || '' === $secret) {
         // If it's not successful, then one or more error codes will be returned.
         ?>
         <h2>Something went wrong</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>Check the error code reference at <kbd><a href="https://developers.google.com/recaptcha/docs/verify#error-code-reference">https://developers.google.com/recaptcha/docs/verify#error-code-reference</a></kbd>.
         <p><strong>Note:</strong> Error code <kbd>missing-input-response</kbd> may mean the user just didn't complete the reCAPTCHA.</p>
         <p><a href="/recaptcha-v2-checkbox.php"><span aria-hidden="true">⤴️</span> Try again</a></p>

--- a/examples/recaptcha-v2-invisible.php
+++ b/examples/recaptcha-v2-invisible.php
@@ -84,7 +84,7 @@ if ('' === $siteKey || '' === $secret) {
     // In production, *always* sanitise and validate your input'
     ?>
         <h2><kbd>POST</kbd> data</h2>
-        <kbd><pre><?php var_export($_POST); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
     // If the form submission includes the "g-captcha-response" field
     // Create an instance of the service using your secret
@@ -113,7 +113,7 @@ if ('' === $siteKey || '' === $secret) {
         // If the response is a success, that's it!
         ?>
         <h2>Success!</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>That's it. Everything is working. Go integrate this into your real project.</p>
         <p><a href="/recaptcha-v2-invisible.php"><span aria-hidden="true">⤴️</span> Try again</a></p>
         <?php
@@ -121,7 +121,7 @@ if ('' === $siteKey || '' === $secret) {
         // If it's not successful, then one or more error codes will be returned.
         ?>
         <h2>Something went wrong</h2>
-        <kbd><pre><?php var_export($resp); ?></pre></kbd>
+        <kbd><pre><?php echo htmlspecialchars(print_r($resp, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <p>Check the error code reference at <kbd><a href="https://developers.google.com/recaptcha/docs/verify#error-code-reference">https://developers.google.com/recaptcha/docs/verify#error-code-reference</a></kbd>.
         <p><strong>Note:</strong> Error code <kbd>missing-input-response</kbd> may mean the user just didn't complete the reCAPTCHA.</p>
         <p><a href="/recaptcha-v2-invisible.php"><span aria-hidden="true">⤴️</span> Try again</a></p>


### PR DESCRIPTION
All 6 example files reflect unsanitized POST data and response objects
directly into HTML via `var_export()` with no encoding, allowing reflected
XSS via the `g-recaptcha-response` parameter.

**PoC :**

```
curl -X POST https://recaptcha-demo.appspot.com/recaptcha-v2-checkbox.php \
  --data-urlencode 'g-recaptcha-response=</pre><img src=x onerror=alert(document.domain)>'
```

**Root cause:**
`var_export($_POST)` and `var_export($resp)` write user-controlled data into
HTML with zero encoding. No `htmlspecialchars()` exists anywhere in examples/.
The `</pre>` in the payload breaks out of the tag and the browser executes
the injected script.

**Fix:**
Replaced all `var_export()` calls with:
`htmlspecialchars(print_r(..., true), ENT_QUOTES | ENT_HTML5, 'UTF-8')`
across 6 files, 18 lines total. No logic changes.

**Files changed:**
- examples/recaptcha-v2-checkbox.php
- examples/recaptcha-v2-checkbox-explicit.php
- examples/recaptcha-v2-invisible.php
- examples/recaptcha-request-curl.php
- examples/recaptcha-request-post.php
- examples/recaptcha-request-socket.php

These files are actively deployed on recaptcha-demo.appspot.com and widely
copied by developers into production insecure patterns here propagate
directly into real applications.