### PR TITLE
Harden Post fallback TLS verification

### DIFF
--- a/src/ReCaptcha/RequestMethod/Post.php
+++ b/src/ReCaptcha/RequestMethod/Post.php
@@ -73,6 +73,10 @@ class Post implements RequestMethod
     public function submit(RequestParameters $params): string
     {
         $options = [
+            'ssl' => [
+                'verify_peer' => true,
+                'verify_peer_name' => true,
+            ],
             'http' => [
                 'header' => "Content-type: application/x-www-form-urlencoded\r\n",
                 'method' => 'POST',

--- a/tests/ReCaptcha/RequestMethod/PostTest.php
+++ b/tests/ReCaptcha/RequestMethod/PostTest.php
@@ -117,9 +117,13 @@ class PostTest extends TestCase
         $context = $args[2];
         $options = stream_context_get_options($context);
         $this->assertArrayHasKey('http', $options);
+        $this->assertArrayHasKey('ssl', $options);
 
         /** @var array<string, mixed> $httpOptions */
         $httpOptions = $options['http'];
+
+        /** @var array<string, mixed> $sslOptions */
+        $sslOptions = $options['ssl'];
 
         $this->assertArrayHasKey('method', $httpOptions);
         $this->assertEquals('POST', $httpOptions['method']);
@@ -135,6 +139,11 @@ class PostTest extends TestCase
 
         $this->assertArrayHasKey('timeout', $httpOptions);
         $this->assertEquals(60, $httpOptions['timeout']);
+
+        $this->assertArrayHasKey('verify_peer', $sslOptions);
+        $this->assertTrue((bool) $sslOptions['verify_peer']);
+        $this->assertArrayHasKey('verify_peer_name', $sslOptions);
+        $this->assertTrue((bool) $sslOptions['verify_peer_name']);
     }
 
     /**


### PR DESCRIPTION
Hi!
This PR hardens the fallback Post request method by explicitly enabling TLS peer verification and peer-name verification in the stream context. This keeps fallback behavior aligned with secure transport expectations when curl is unavailable.


The fallback path is used in environments without curl, so it should still enforce strict certificate checks. Without explicit SSL options, behavior can depend on runtime defaults.

What changed
Added ssl context options:
- verify_peer => true
- verify_peer_name => true
- Expanded Post request-method test coverage to assert these SSL options are present and true.

Files
- [Post.php]
- [PostTest.php]


Validation

- PHPUnit passed: 69 tests, 190 assertions
- PHPStan passed with no errors
- PHP-CS-Fixer check passed for modified files