### PR TITLE
Restore 1.x API compatibility while keeping 1.5 hardening

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,7 +44,8 @@ appropriate.
 The 1.x line treats the following classes and interfaces as public API:
 `ReCaptcha`, `RequestMethod`, `Response`, `RequestParameters`,
 `RequestMethod\Post`, `RequestMethod\CurlPost`, and
-`RequestMethod\SocketPost`.
+`RequestMethod\SocketPost`, plus the request wrapper classes
+`RequestMethod\Curl` and `RequestMethod\Socket`.
 
 Changes that narrow those APIs, such as adding native scalar parameter types,
 adding native return types to existing public methods, making public non-final

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,3 +38,19 @@ with additional error codes based on the client's checks. When adding a new
 [`RequestMethod`](./src/ReCaptcha/RequestMethod.php) ensure that it returns the
 `ReCaptcha::E_CONNECTION_FAILED` and `ReCaptcha::E_BAD_RESPONSE` where
 appropriate.
+
+## Public API compatibility
+
+The 1.x line treats the following classes and interfaces as public API:
+`ReCaptcha`, `RequestMethod`, `Response`, `RequestParameters`,
+`RequestMethod\Post`, `RequestMethod\CurlPost`, and
+`RequestMethod\SocketPost`.
+
+Changes that narrow those APIs, such as adding native scalar parameter types,
+adding native return types to existing public methods, making public non-final
+classes `readonly` or `final`, removing public classes, or removing existing
+constructor argument forms, should be reserved for a major release.
+
+The `RequestMethod::submit()` interface intentionally keeps its 1.x-compatible
+native signature. Implementations are still expected to return the body of the
+reCAPTCHA response as a string.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,3 +55,25 @@ constructor argument forms, should be reserved for a major release.
 The `RequestMethod::submit()` interface intentionally keeps its 1.x-compatible
 native signature. Implementations are still expected to return the body of the
 reCAPTCHA response as a string.
+
+### 1.5.1 Compatibility Focus
+
+Release 1.5.1 restores 1.4.x compatibility and keeps the 1.5.0 reliability fixes.
+
+- Restored 1.x public API contracts by removing narrowing type hints and `readonly` modifiers from public non-final DTOs.
+- Kept custom `RequestMethod` implementations working without native return types.
+- Kept legacy input handling for compatibility.
+- Fixed deprecated `curl_close()` usage for PHP 8.5+.
+- Kept the cURL handle cleanup, HTTP/1.1 handling, and TLS verification changes.
+
+### BC Testing
+
+The test suite covers the backward compatibility cases below:
+
+- `testLegacyRequestMethodImplementationWithoutReturnTypeCanBeUsed()`: Custom implementations without strict return types.
+- `testNonStringRequestMethodResponseReturnsBadResponse()`: Non-string responses from custom implementations.
+- `testScalarResponseIsAccepted()`: Scalar inputs such as integers in `verify()`.
+- `testZeroAsStringIsValidResponse()`: The "0" response token.
+- `testVerifyReturnsErrorOnNullResponse()`: Null input handling.
+
+These tests document expected 1.x behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,25 @@ a good idea to run them locally before submission to avoid getting things
 bounced back. That said, tests can be a little daunting so feel free to submit
 your PR and ask for help.
 
+### Backward Compatibility Testing
+
+Changes to public APIs must preserve backward compatibility within the 1.x
+release line. When changes affect public methods, parameters, or return types,
+include tests for:
+
+1. Legacy implementation support. If interface contracts change, verify that old
+   implementations still work without modification.
+2. Type coercion scenarios. Verify that null, scalar, and non-standard inputs
+   behave as they did in 1.4.x.
+3. Custom `RequestMethod` implementations. Verify that user-provided
+   implementations continue to work without return type declarations.
+
+See the BC-focused tests in [`ReCaptchaTest.php`](./tests/ReCaptcha/ReCaptchaTest.php):
+- `testLegacyRequestMethodImplementationWithoutReturnTypeCanBeUsed()`
+- `testNonStringRequestMethodResponseReturnsBadResponse()`
+- `testScalarResponseIsAccepted()`
+- `testZeroAsStringIsValidResponse()`
+
 ## Code reviews
 
 All submissions, including submissions by project members, require review.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,33 @@ The 1.x line preserves compatibility for the public request and response APIs.
 See [Public API compatibility](ARCHITECTURE.md#public-api-compatibility) for
 details on which API changes require a major release.
 
+The following classes and interfaces are treated as public API in 1.x:
+
+- `ReCaptcha\ReCaptcha`
+- `ReCaptcha\RequestMethod`
+- `ReCaptcha\Response`
+- `ReCaptcha\RequestParameters`
+- `ReCaptcha\RequestMethod\Post`
+- `ReCaptcha\RequestMethod\CurlPost`
+- `ReCaptcha\RequestMethod\SocketPost`
+- `ReCaptcha\RequestMethod\Curl`
+- `ReCaptcha\RequestMethod\Socket`
+
+### 1.5.1 compatibility release notes
+
+The 1.5.1 compatibility release restores 1.x API behavior while keeping the
+hardening and reliability updates from 1.5.0:
+
+- `RequestMethod::submit()` remains compatible with legacy implementations, and
+  `ReCaptcha::verify()` validates non-string request-method responses.
+- Public non-final DTOs (`Response`, `RequestParameters`) remain extendable.
+- Legacy `CurlPost` and `SocketPost` constructor forms are supported,
+  including source-compatible named arguments.
+- Legacy `Curl` and `Socket` wrappers are available for source compatibility.
+- `SocketPost` closes the handle when timeout setup fails.
+- `CurlPost` always closes cURL handles.
+- Fallback request methods continue to enforce TLS peer verification.
+
 ### Examples
 
 You can see examples of each reCAPTCHA type in [examples/](examples/). You can

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ $recaptcha = new \ReCaptcha\ReCaptcha($secret, new \ReCaptcha\RequestMethod\Sock
 
 For more details on usage and structure, see [ARCHITECTURE](ARCHITECTURE.md).
 
+The 1.x line preserves compatibility for the public request and response APIs.
+See [Public API compatibility](ARCHITECTURE.md#public-api-compatibility) for
+details on which API changes require a major release.
+
 ### Examples
 
 You can see examples of each reCAPTCHA type in [examples/](examples/). You can

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This library comes in when you need to verify the user's response. On the PHP
 side you need the response from the reCAPTCHA service and secret key from your
 credentials. Instantiate the `ReCaptcha` class with your secret key, specify any
 additional validation rules, and then call `verify()` with the reCAPTCHA
-response (usually in `$_POST[\ReCaptcha\ReCaptcha::USER_TOKEN_PARAMETER]` or the
+response (usually in `$_POST[\ReCaptcha\ReCaptcha::RESPONSE_KEY]` or the
 response from `grecaptcha.execute()` in JS which is in `$gRecaptchaResponse` in
 the example) and user's IP address. For example:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and v3.
 - reCAPTCHA: https://cloud.google.com/security/products/recaptcha
 - This repo: https://github.com/google/recaptcha
 - Hosted demo: https://recaptcha-demo.appspot.com/
-- Version: 1.5.0
+- Version: 1.5.1
 - License: BSD, see [LICENSE](LICENSE)
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -173,32 +173,6 @@ The 1.x line preserves compatibility for the public request and response APIs.
 See [Public API compatibility](ARCHITECTURE.md#public-api-compatibility) for
 details on which API changes require a major release.
 
-The following classes and interfaces are treated as public API in 1.x:
-
-- `ReCaptcha\ReCaptcha`
-- `ReCaptcha\RequestMethod`
-- `ReCaptcha\Response`
-- `ReCaptcha\RequestParameters`
-- `ReCaptcha\RequestMethod\Post`
-- `ReCaptcha\RequestMethod\CurlPost`
-- `ReCaptcha\RequestMethod\SocketPost`
-- `ReCaptcha\RequestMethod\Curl`
-- `ReCaptcha\RequestMethod\Socket`
-
-### 1.5.1 compatibility release notes
-
-The 1.5.1 compatibility release restores 1.x API behavior while keeping the
-hardening and reliability updates from 1.5.0:
-
-- `RequestMethod::submit()` remains compatible with legacy implementations, and
-  `ReCaptcha::verify()` validates non-string request-method responses.
-- Public non-final DTOs (`Response`, `RequestParameters`) remain extendable.
-- Legacy `CurlPost` and `SocketPost` constructor forms are supported,
-  including source-compatible named arguments.
-- Legacy `Curl` and `Socket` wrappers are available for source compatibility.
-- `SocketPost` closes the handle when timeout setup fails.
-- `CurlPost` always closes cURL handles.
-- Fallback request methods continue to enforce TLS peer verification.
 
 ### Examples
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.4.x-dev"
+            "dev-main": "1.5.x-dev"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "lint": "vendor/bin/php-cs-fixer -vvv check --using-cache=no",
         "lint-fix": "vendor/bin/php-cs-fixer -vvv fix --using-cache=no",
         "phpstan": "vendor/bin/phpstan",
-        "test": "XDEBUG_MODE=coverage vendor/bin/phpunit",
+        "test": "@php -d xdebug.mode=coverage vendor/bin/phpunit",
         "serve-examples": "@php -S localhost:8080 -t examples"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f9f7f08c81bbc8765f5b1ea64677736",
+    "content-hash": "5a1a38d86c0d9b0bff77a744deb968ab",
     "packages": [],
     "packages-dev": [
         {
@@ -1222,11 +1222,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.51",
+            "version": "2.1.54",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc3b523c45e714c70de2ac5113b958223b55dc59",
-                "reference": "dc3b523c45e714c70de2ac5113b958223b55dc59",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
                 "shasum": ""
             },
             "require": {
@@ -1271,7 +1271,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-21T18:22:01+00:00"
+            "time": "2026-04-29T13:31:09+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1658,16 +1658,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "13.1.7",
+            "version": "13.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "ddd6401641861cdef94b922ef10d484f436e8dcd"
+                "reference": "f49a2b5e51ffb33421745368cc099cf66830d71b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ddd6401641861cdef94b922ef10d484f436e8dcd",
-                "reference": "ddd6401641861cdef94b922ef10d484f436e8dcd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f49a2b5e51ffb33421745368cc099cf66830d71b",
+                "reference": "f49a2b5e51ffb33421745368cc099cf66830d71b",
                 "shasum": ""
             },
             "require": {
@@ -1681,7 +1681,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.4.1",
-                "phpunit/php-code-coverage": "^14.1.3",
+                "phpunit/php-code-coverage": "^14.1.6",
                 "phpunit/php-file-iterator": "^7.0.0",
                 "phpunit/php-invoker": "^7.0.0",
                 "phpunit/php-text-template": "^6.0.0",
@@ -1737,7 +1737,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.7"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/13.1.8"
             },
             "funding": [
                 {
@@ -1745,7 +1745,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-18T06:14:52+00:00"
+            "time": "2026-05-01T04:22:45+00:00"
         },
         {
             "name": "psr/container",
@@ -3722,16 +3722,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v8.0.8",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "c7369cc1da250fcbfe0c5a9d109e419661549c39"
+                "reference": "7e712ee3c98ec114f674adc4fbad4c2fe7526b9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/c7369cc1da250fcbfe0c5a9d109e419661549c39",
-                "reference": "c7369cc1da250fcbfe0c5a9d109e419661549c39",
+                "url": "https://api.github.com/repos/symfony/config/zipball/7e712ee3c98ec114f674adc4fbad4c2fe7526b9c",
+                "reference": "7e712ee3c98ec114f674adc4fbad4c2fe7526b9c",
                 "shasum": ""
             },
             "require": {
@@ -3776,7 +3776,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v8.0.8"
+                "source": "https://github.com/symfony/config/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -3796,20 +3796,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v8.0.8",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7"
+                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5b66d385dc58f69652e56f78a4184615e3f2b7f7",
-                "reference": "5b66d385dc58f69652e56f78a4184615e3f2b7f7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7113778e2e91f4709cb3194a75dfa9c0d028d94d",
+                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d",
                 "shasum": ""
             },
             "require": {
@@ -3866,7 +3866,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.0.8"
+                "source": "https://github.com/symfony/console/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -3886,7 +3886,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-04-29T15:02:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3957,16 +3957,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.0.8",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "f662acc6ab22a3d6d716dcb44c381c6002940df6"
+                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f662acc6ab22a3d6d716dcb44c381c6002940df6",
-                "reference": "f662acc6ab22a3d6d716dcb44c381c6002940df6",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0c3c1a17604c4dbbec4b93fe162c538482096e1f",
+                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f",
                 "shasum": ""
             },
             "require": {
@@ -4018,7 +4018,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.8"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -4038,7 +4038,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-04-18T13:51:42+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -4118,16 +4118,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v8.0.8",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a"
+                "reference": "d1ec4543d5c6c2dac78503c2fae5ea0b3608ce40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/66b769ae743ce2d13e435528fbef4af03d623e5a",
-                "reference": "66b769ae743ce2d13e435528fbef4af03d623e5a",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d1ec4543d5c6c2dac78503c2fae5ea0b3608ce40",
+                "reference": "d1ec4543d5c6c2dac78503c2fae5ea0b3608ce40",
                 "shasum": ""
             },
             "require": {
@@ -4164,7 +4164,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.0.8"
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -4184,7 +4184,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-04-18T13:51:42+00:00"
         },
         {
             "name": "symfony/finder",
@@ -5347,5 +5347,5 @@
         "php": ">=8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/examples/recaptcha-request-curl.php
+++ b/examples/recaptcha-request-curl.php
@@ -89,14 +89,14 @@ if ('' === $siteKey || '' === $secret) {
         <h2><kbd>POST</kbd> data</h2>
         <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
-    // If the form submission includes the "g-captcha-response" field
+    // If the form submission includes the "g-recaptcha-response" field
     // Create an instance of the service using your secret and the CurlPost request method.
     /** @var string $secret */
     $recaptcha = new ReCaptcha($secret, new CurlPost());
 
     // Make the call to verify the response and also pass the user's IP address
     /** @var string $serverName */
-    $serverName = $_SERVER['SERVER_NAME'];
+    $serverName = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? '';
 
     /** @var string $responseKey */
     $responseKey = $_POST[ReCaptcha::RESPONSE_KEY];

--- a/examples/recaptcha-request-post.php
+++ b/examples/recaptcha-request-post.php
@@ -88,14 +88,14 @@ if ('' === $siteKey || '' === $secret) {
         <h2><kbd>POST</kbd> data</h2>
         <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
-    // If the form submission includes the "g-captcha-response" field
+    // If the form submission includes the "g-recaptcha-response" field
     // Create an instance of the service using your secret and the Post request method.
     /** @var string $secret */
     $recaptcha = new ReCaptcha($secret, new Post());
 
     // Make the call to verify the response and also pass the user's IP address
     /** @var string $serverName */
-    $serverName = $_SERVER['SERVER_NAME'];
+    $serverName = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? '';
 
     /** @var string $responseKey */
     $responseKey = $_POST[ReCaptcha::RESPONSE_KEY];

--- a/examples/recaptcha-request-socket.php
+++ b/examples/recaptcha-request-socket.php
@@ -87,14 +87,14 @@ if ('' === $siteKey || '' === $secret) {
         <h2><kbd>POST</kbd> data</h2>
         <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
-    // If the form submission includes the "g-captcha-response" field
+    // If the form submission includes the "g-recaptcha-response" field
     // Create an instance of the service using your secret and the SocketPost request method.
     /** @var string $secret */
     $recaptcha = new ReCaptcha($secret, new SocketPost());
 
     // Make the call to verify the response and also pass the user's IP address
     /** @var string $serverName */
-    $serverName = $_SERVER['SERVER_NAME'];
+    $serverName = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? '';
 
     /** @var string $responseKey */
     $responseKey = $_POST[ReCaptcha::RESPONSE_KEY];

--- a/examples/recaptcha-v2-checkbox-explicit.php
+++ b/examples/recaptcha-v2-checkbox-explicit.php
@@ -86,7 +86,7 @@ if ('' === $siteKey || '' === $secret) {
         <h2><kbd>POST</kbd> data</h2>
         <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
-    // If the form submission includes the "g-captcha-response" field
+    // If the form submission includes the "g-recaptcha-response" field
     // Create an instance of the service using your secret
     /** @var string $secret */
     $recaptcha = new ReCaptcha($secret);
@@ -97,7 +97,7 @@ if ('' === $siteKey || '' === $secret) {
     //  $recaptcha = new \ReCaptcha\ReCaptcha($secret, new \ReCaptcha\RequestMethod\SocketPost());
     // Make the call to verify the response and also pass the user's IP address
     /** @var string $serverName */
-    $serverName = $_SERVER['SERVER_NAME'];
+    $serverName = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? '';
 
     /** @var string $responseKey */
     $responseKey = $_POST[ReCaptcha::RESPONSE_KEY];

--- a/examples/recaptcha-v2-checkbox.php
+++ b/examples/recaptcha-v2-checkbox.php
@@ -86,7 +86,7 @@ if ('' === $siteKey || '' === $secret) {
         <h2><kbd>POST</kbd> data</h2>
         <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
-    // If the form submission includes the "g-captcha-response" field
+    // If the form submission includes the "g-recaptcha-response" field
     // Create an instance of the service using your secret
     /** @var string $secret */
     $recaptcha = new ReCaptcha($secret);
@@ -98,7 +98,7 @@ if ('' === $siteKey || '' === $secret) {
 
     // Make the call to verify the response and also pass the user's IP address
     /** @var string $serverName */
-    $serverName = $_SERVER['SERVER_NAME'];
+    $serverName = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? '';
 
     /** @var string $responseKey */
     $responseKey = $_POST[ReCaptcha::RESPONSE_KEY];

--- a/examples/recaptcha-v2-invisible.php
+++ b/examples/recaptcha-v2-invisible.php
@@ -86,7 +86,7 @@ if ('' === $siteKey || '' === $secret) {
         <h2><kbd>POST</kbd> data</h2>
         <kbd><pre><?php echo htmlspecialchars(print_r($_POST, true), ENT_QUOTES | ENT_HTML5, 'UTF-8'); ?></pre></kbd>
         <?php
-    // If the form submission includes the "g-captcha-response" field
+    // If the form submission includes the "g-recaptcha-response" field
     // Create an instance of the service using your secret
     /** @var string $secret */
     $recaptcha = new ReCaptcha($secret);
@@ -98,7 +98,7 @@ if ('' === $siteKey || '' === $secret) {
 
     // Make the call to verify the response and also pass the user's IP address
     /** @var string $serverName */
-    $serverName = $_SERVER['SERVER_NAME'];
+    $serverName = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? '';
 
     /** @var string $responseKey */
     $responseKey = $_POST[ReCaptcha::RESPONSE_KEY];

--- a/examples/recaptcha-v3-verify.php
+++ b/examples/recaptcha-v3-verify.php
@@ -57,13 +57,13 @@ if (('' === $siteKey || '' === $secret) && is_readable(__DIR__.'/config.php')) {
 $recaptcha = new ReCaptcha($secret);
 
 /** @var string $serverName */
-$serverName = $_SERVER['SERVER_NAME'];
+$serverName = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? '';
 
 /** @var string $action */
-$action = $_GET['action'];
+$action = $_GET['action'] ?? '';
 
 /** @var string $token */
-$token = $_GET['token'];
+$token = $_GET['token'] ?? '';
 
 /** @var null|string $remoteAddr */
 $remoteAddr = $_SERVER['REMOTE_ADDR'];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     level: max
+    treatPhpDocTypesAsCertain: false
     paths:
         - src
         - tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,7 @@
 parameters:
     level: max
+    # A custom RequestMethod implementation is not bound by the interface phpdoc,
+    # so runtime guards on values it returns are meaningful rather than redundant.
     treatPhpDocTypesAsCertain: false
     paths:
         - src

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,7 @@
 parameters:
     level: max
     # A custom RequestMethod implementation is not bound by the interface phpdoc,
-    # so runtime guards on values it returns are meaningful rather than redundant.
+    # so runtime guards on the values it returns are meaningful, not redundant.
     treatPhpDocTypesAsCertain: false
     paths:
         - src

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -49,7 +49,7 @@ class ReCaptcha
      *
      * @var string
      */
-    public const VERSION = 'php_1.5.0';
+    public const VERSION = 'php_1.5.1';
 
     /**
      * URL for reCAPTCHA siteverify API.

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -191,8 +191,10 @@ class ReCaptcha
      */
     public function verify($response, $remoteIp = null)
     {
+        $response = self::stringValue($response);
+
         // Discard empty solution submissions
-        if (!is_string($response) || '' === $response) {
+        if ('' === $response) {
             return new Response(false, [self::E_MISSING_INPUT_RESPONSE]);
         }
 

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -154,13 +154,17 @@ class ReCaptcha
     /**
      * Create a configured instance to use the reCAPTCHA service.
      *
-     * @param string        $secret        the shared key between your site and reCAPTCHA
+     * @param mixed         $secret        the shared key between your site and reCAPTCHA
      * @param RequestMethod $requestMethod method used to send the request. Defaults to POST.
      *
      * @throws \RuntimeException if $secret is invalid
      */
-    public function __construct(string $secret, ?RequestMethod $requestMethod = null)
+    public function __construct($secret, ?RequestMethod $requestMethod = null)
     {
+        if (!is_string($secret)) {
+            throw new \RuntimeException('The provided secret must be a string');
+        }
+
         if ('' === $secret) {
             throw new \RuntimeException('No secret provided');
         }
@@ -180,20 +184,26 @@ class ReCaptcha
      * Calls the reCAPTCHA siteverify API to verify whether the user passes
      * CAPTCHA test and additionally runs any specified additional checks.
      *
-     * @param string      $response the user response token provided by reCAPTCHA, verifying the user on your site
-     * @param null|string $remoteIp the end user's IP address
+     * @param mixed $response the user response token provided by reCAPTCHA, verifying the user on your site
+     * @param mixed $remoteIp the end user's IP address
      *
      * @return Response response from the service
      */
-    public function verify(string $response, ?string $remoteIp = null): Response
+    public function verify($response, $remoteIp = null)
     {
         // Discard empty solution submissions
-        if ('' === $response) {
+        if (!is_string($response) || '' === $response) {
             return new Response(false, [self::E_MISSING_INPUT_RESPONSE]);
         }
 
+        $remoteIp = self::nullableStringValue($remoteIp);
         $params = new RequestParameters($this->secret, $response, $remoteIp, self::VERSION);
         $rawResponse = $this->requestMethod->submit($params);
+
+        if (!is_string($rawResponse)) {
+            return new Response(false, [self::E_BAD_RESPONSE]);
+        }
+
         $initialResponse = Response::fromJson($rawResponse);
         $validationErrors = [];
 
@@ -240,13 +250,13 @@ class ReCaptcha
      * Provide a hostname to match against in verify()
      * This should be without a protocol or trailing slash, e.g. www.google.com.
      *
-     * @param string $hostname Expected hostname
+     * @param mixed $hostname Expected hostname
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setExpectedHostname(string $hostname): self
+    public function setExpectedHostname($hostname)
     {
-        $this->hostname = $hostname;
+        $this->hostname = self::stringValue($hostname);
 
         return $this;
     }
@@ -254,13 +264,13 @@ class ReCaptcha
     /**
      * Provide an APK package name to match against in verify().
      *
-     * @param string $apkPackageName Expected APK package name
+     * @param mixed $apkPackageName Expected APK package name
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setExpectedApkPackageName(string $apkPackageName): self
+    public function setExpectedApkPackageName($apkPackageName)
     {
-        $this->apkPackageName = $apkPackageName;
+        $this->apkPackageName = self::stringValue($apkPackageName);
 
         return $this;
     }
@@ -269,13 +279,13 @@ class ReCaptcha
      * Provide an action to match against in verify()
      * This should be set per page.
      *
-     * @param string $action Expected action
+     * @param mixed $action Expected action
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setExpectedAction(string $action): self
+    public function setExpectedAction($action)
     {
-        $this->action = $action;
+        $this->action = self::stringValue($action);
 
         return $this;
     }
@@ -284,13 +294,13 @@ class ReCaptcha
      * Provide a threshold to meet or exceed in verify()
      * Threshold should be a float between 0 and 1 which will be tested as response >= threshold.
      *
-     * @param float $threshold Expected threshold
+     * @param mixed $threshold Expected threshold
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setScoreThreshold(float $threshold): self
+    public function setScoreThreshold($threshold)
     {
-        $this->threshold = $threshold;
+        $this->threshold = self::floatValue($threshold);
 
         return $this;
     }
@@ -298,14 +308,50 @@ class ReCaptcha
     /**
      * Provide a timeout in seconds to test against the challenge timestamp in verify().
      *
-     * @param int $timeoutSeconds Maximum time (seconds) elapsed since the challenge timestamp
+     * @param mixed $timeoutSeconds Maximum time (seconds) elapsed since the challenge timestamp
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setChallengeTimeout(int $timeoutSeconds): self
+    public function setChallengeTimeout($timeoutSeconds)
     {
-        $this->timeoutSeconds = $timeoutSeconds;
+        $this->timeoutSeconds = self::intValue($timeoutSeconds);
 
         return $this;
+    }
+
+    private static function nullableStringValue(mixed $value): ?string
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        return self::stringValue($value);
+    }
+
+    private static function stringValue(mixed $value): string
+    {
+        if (is_scalar($value) || $value instanceof \Stringable) {
+            return (string) $value;
+        }
+
+        return '';
+    }
+
+    private static function floatValue(mixed $value): float
+    {
+        if (is_null($value) || is_scalar($value)) {
+            return floatval($value);
+        }
+
+        return 0.0;
+    }
+
+    private static function intValue(mixed $value): int
+    {
+        if (is_null($value) || is_scalar($value)) {
+            return intval($value);
+        }
+
+        return 0;
     }
 }

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -184,8 +184,8 @@ class ReCaptcha
      * Calls the reCAPTCHA siteverify API to verify whether the user passes
      * CAPTCHA test and additionally runs any specified additional checks.
      *
-     * @param mixed $response the user response token provided by reCAPTCHA, verifying the user on your site
-     * @param mixed $remoteIp the end user's IP address
+     * @param string      $response the user response token provided by reCAPTCHA, verifying the user on your site
+     * @param null|string $remoteIp the end user's IP address
      *
      * @return Response response from the service
      */
@@ -202,6 +202,7 @@ class ReCaptcha
         $params = new RequestParameters($this->secret, $response, $remoteIp, self::VERSION);
         $rawResponse = $this->requestMethod->submit($params);
 
+        // @phpstan-ignore function.alreadyNarrowedType
         if (!is_string($rawResponse)) {
             return new Response(false, [self::E_BAD_RESPONSE]);
         }
@@ -252,7 +253,7 @@ class ReCaptcha
      * Provide a hostname to match against in verify()
      * This should be without a protocol or trailing slash, e.g. www.google.com.
      *
-     * @param mixed $hostname Expected hostname
+     * @param string $hostname Expected hostname
      *
      * @return ReCaptcha Current instance for fluent interface
      */
@@ -266,7 +267,7 @@ class ReCaptcha
     /**
      * Provide an APK package name to match against in verify().
      *
-     * @param mixed $apkPackageName Expected APK package name
+     * @param string $apkPackageName Expected APK package name
      *
      * @return ReCaptcha Current instance for fluent interface
      */
@@ -281,7 +282,7 @@ class ReCaptcha
      * Provide an action to match against in verify()
      * This should be set per page.
      *
-     * @param mixed $action Expected action
+     * @param string $action Expected action
      *
      * @return ReCaptcha Current instance for fluent interface
      */
@@ -296,7 +297,7 @@ class ReCaptcha
      * Provide a threshold to meet or exceed in verify()
      * Threshold should be a float between 0 and 1 which will be tested as response >= threshold.
      *
-     * @param mixed $threshold Expected threshold
+     * @param float $threshold Expected threshold
      *
      * @return ReCaptcha Current instance for fluent interface
      */
@@ -310,7 +311,7 @@ class ReCaptcha
     /**
      * Provide a timeout in seconds to test against the challenge timestamp in verify().
      *
-     * @param mixed $timeoutSeconds Maximum time (seconds) elapsed since the challenge timestamp
+     * @param int $timeoutSeconds Maximum time (seconds) elapsed since the challenge timestamp
      *
      * @return ReCaptcha Current instance for fluent interface
      */

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -47,7 +47,7 @@ class ReCaptcha
      *
      * @var string
      */
-    public const VERSION = 'php_1.5.1';
+    public const VERSION = 'php_1.4.2';
 
     /**
      * URL for reCAPTCHA siteverify API.

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -137,41 +135,64 @@ class ReCaptcha
 
     /**
      * Shared secret for the site.
+     *
+     * @var string
      */
-    private string $secret;
+    private $secret;
 
     /**
      * Method used to communicate with service. Defaults to POST request.
+     *
+     * @var RequestMethod
      */
-    private RequestMethod $requestMethod;
+    private $requestMethod;
 
-    private ?string $hostname = null;
-    private ?string $apkPackageName = null;
-    private ?string $action = null;
-    private ?float $threshold = null;
-    private ?int $timeoutSeconds = null;
+    /**
+     * @var null|string
+     */
+    private $hostname;
+
+    /**
+     * @var null|string
+     */
+    private $apkPackageName;
+
+    /**
+     * @var null|string
+     */
+    private $action;
+
+    /**
+     * @var null|float
+     */
+    private $threshold;
+
+    /**
+     * @var null|int
+     */
+    private $timeoutSeconds;
 
     /**
      * Create a configured instance to use the reCAPTCHA service.
      *
-     * @param mixed         $secret        the shared key between your site and reCAPTCHA
+     * @param mixed         $secret        the shared key between your site and reCAPTCHA; must be a non-empty string
      * @param RequestMethod $requestMethod method used to send the request. Defaults to POST.
      *
      * @throws \RuntimeException if $secret is invalid
      */
     public function __construct($secret, ?RequestMethod $requestMethod = null)
     {
+        if (empty($secret)) {
+            throw new \RuntimeException('No secret provided');
+        }
+
         if (!is_string($secret)) {
             throw new \RuntimeException('The provided secret must be a string');
         }
 
-        if ('' === $secret) {
-            throw new \RuntimeException('No secret provided');
-        }
-
         $this->secret = $secret;
 
-        if (null !== $requestMethod) {
+        if (!is_null($requestMethod)) {
             $this->requestMethod = $requestMethod;
         } elseif (function_exists('curl_version')) {
             $this->requestMethod = new RequestMethod\CurlPost();
@@ -184,25 +205,21 @@ class ReCaptcha
      * Calls the reCAPTCHA siteverify API to verify whether the user passes
      * CAPTCHA test and additionally runs any specified additional checks.
      *
-     * @param string      $response the user response token provided by reCAPTCHA, verifying the user on your site
-     * @param null|string $remoteIp the end user's IP address
+     * @param string $response the user response token provided by reCAPTCHA, verifying the user on your site
+     * @param string $remoteIp the end user's IP address
      *
      * @return Response response from the service
      */
     public function verify($response, $remoteIp = null)
     {
-        $response = self::stringValue($response);
-
         // Discard empty solution submissions
-        if ('' === $response) {
+        if (empty($response)) {
             return new Response(false, [self::E_MISSING_INPUT_RESPONSE]);
         }
 
-        $remoteIp = self::nullableStringValue($remoteIp);
         $params = new RequestParameters($this->secret, $response, $remoteIp, self::VERSION);
         $rawResponse = $this->requestMethod->submit($params);
 
-        // @phpstan-ignore function.alreadyNarrowedType
         if (!is_string($rawResponse)) {
             return new Response(false, [self::E_BAD_RESPONSE]);
         }
@@ -210,23 +227,23 @@ class ReCaptcha
         $initialResponse = Response::fromJson($rawResponse);
         $validationErrors = [];
 
-        if (null !== $this->hostname && 0 !== strcasecmp($this->hostname, $initialResponse->getHostname())) {
+        if (isset($this->hostname) && 0 !== strcasecmp($this->hostname, $initialResponse->getHostname())) {
             $validationErrors[] = self::E_HOSTNAME_MISMATCH;
         }
 
-        if (null !== $this->apkPackageName && 0 !== strcasecmp($this->apkPackageName, $initialResponse->getApkPackageName())) {
+        if (isset($this->apkPackageName) && 0 !== strcasecmp($this->apkPackageName, $initialResponse->getApkPackageName())) {
             $validationErrors[] = self::E_APK_PACKAGE_NAME_MISMATCH;
         }
 
-        if (null !== $this->action && 0 !== strcasecmp($this->action, $initialResponse->getAction())) {
+        if (isset($this->action) && 0 !== strcasecmp($this->action, $initialResponse->getAction())) {
             $validationErrors[] = self::E_ACTION_MISMATCH;
         }
 
-        if (null !== $this->threshold && $this->threshold > $initialResponse->getScore()) {
+        if (isset($this->threshold) && $this->threshold > $initialResponse->getScore()) {
             $validationErrors[] = self::E_SCORE_THRESHOLD_NOT_MET;
         }
 
-        if (null !== $this->timeoutSeconds) {
+        if (isset($this->timeoutSeconds)) {
             $challengeTs = strtotime($initialResponse->getChallengeTs());
 
             if ($challengeTs > 0 && time() - $challengeTs > $this->timeoutSeconds) {
@@ -259,7 +276,7 @@ class ReCaptcha
      */
     public function setExpectedHostname($hostname)
     {
-        $this->hostname = self::stringValue($hostname);
+        $this->hostname = $hostname;
 
         return $this;
     }
@@ -273,7 +290,7 @@ class ReCaptcha
      */
     public function setExpectedApkPackageName($apkPackageName)
     {
-        $this->apkPackageName = self::stringValue($apkPackageName);
+        $this->apkPackageName = $apkPackageName;
 
         return $this;
     }
@@ -288,7 +305,7 @@ class ReCaptcha
      */
     public function setExpectedAction($action)
     {
-        $this->action = self::stringValue($action);
+        $this->action = $action;
 
         return $this;
     }
@@ -297,13 +314,13 @@ class ReCaptcha
      * Provide a threshold to meet or exceed in verify()
      * Threshold should be a float between 0 and 1 which will be tested as response >= threshold.
      *
-     * @param float $threshold Expected threshold
+     * @param float|int|string $threshold Expected threshold
      *
      * @return ReCaptcha Current instance for fluent interface
      */
     public function setScoreThreshold($threshold)
     {
-        $this->threshold = self::floatValue($threshold);
+        $this->threshold = floatval($threshold);
 
         return $this;
     }
@@ -317,44 +334,8 @@ class ReCaptcha
      */
     public function setChallengeTimeout($timeoutSeconds)
     {
-        $this->timeoutSeconds = self::intValue($timeoutSeconds);
+        $this->timeoutSeconds = $timeoutSeconds;
 
         return $this;
-    }
-
-    private static function nullableStringValue(mixed $value): ?string
-    {
-        if (is_null($value)) {
-            return null;
-        }
-
-        return self::stringValue($value);
-    }
-
-    private static function stringValue(mixed $value): string
-    {
-        if (is_scalar($value) || $value instanceof \Stringable) {
-            return (string) $value;
-        }
-
-        return '';
-    }
-
-    private static function floatValue(mixed $value): float
-    {
-        if (is_null($value) || is_scalar($value)) {
-            return floatval($value);
-        }
-
-        return 0.0;
-    }
-
-    private static function intValue(mixed $value): int
-    {
-        if (is_null($value) || is_scalar($value)) {
-            return intval($value);
-        }
-
-        return 0;
     }
 }

--- a/src/ReCaptcha/RequestMethod.php
+++ b/src/ReCaptcha/RequestMethod.php
@@ -49,7 +49,7 @@ interface RequestMethod
      *
      * @param RequestParameters $params Request parameters
      *
-     * @return string Body of the reCAPTCHA response
+     * @return mixed Body of the reCAPTCHA response
      */
-    public function submit(RequestParameters $params): string;
+    public function submit(RequestParameters $params);
 }

--- a/src/ReCaptcha/RequestMethod.php
+++ b/src/ReCaptcha/RequestMethod.php
@@ -49,7 +49,7 @@ interface RequestMethod
      *
      * @param RequestParameters $params Request parameters
      *
-     * @return mixed Body of the reCAPTCHA response
+     * @return string Body of the reCAPTCHA response
      */
     public function submit(RequestParameters $params);
 }

--- a/src/ReCaptcha/RequestMethod.php
+++ b/src/ReCaptcha/RequestMethod.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *

--- a/src/ReCaptcha/RequestMethod/Curl.php
+++ b/src/ReCaptcha/RequestMethod/Curl.php
@@ -37,82 +37,50 @@ declare(strict_types=1);
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace ReCaptcha;
+namespace ReCaptcha\RequestMethod;
 
 /**
- * Stores and formats the parameters for the request to the reCAPTCHA service.
+ * Convenience wrapper around the cURL functions to allow mocking.
  */
-class RequestParameters
+class Curl
 {
-    private string $secret;
-
-    private string $response;
-
-    private ?string $remoteIp;
-
-    private ?string $version;
-
     /**
-     * Initialise parameters.
+     * @param null|string $url
      *
-     * @param mixed $secret   site secret
-     * @param mixed $response value from g-captcha-response form field
-     * @param mixed $remoteIp user's IP address
-     * @param mixed $version  version of this client library
+     * @return mixed
      */
-    public function __construct($secret, $response, $remoteIp = null, $version = null)
+    public function init($url = null)
     {
-        $this->secret = self::stringValue($secret);
-        $this->response = self::stringValue($response);
-        $this->remoteIp = self::nullableStringValue($remoteIp);
-        $this->version = self::nullableStringValue($version);
+        return curl_init($url);
     }
 
     /**
-     * Array representation.
-     *
-     * @return array<string, string> array formatted parameters
+     * @param mixed             $ch
+     * @param array<int, mixed> $options
      */
-    public function toArray()
+    public function setoptArray($ch, array $options): bool
     {
-        $params = ['secret' => $this->secret, 'response' => $this->response];
-
-        if (!is_null($this->remoteIp)) {
-            $params['remoteip'] = $this->remoteIp;
-        }
-
-        if (!is_null($this->version)) {
-            $params['version'] = $this->version;
-        }
-
-        return $params;
+        // @phpstan-ignore argument.type
+        return curl_setopt_array($ch, $options);
     }
 
     /**
-     * Query string representation for HTTP request.
+     * @param mixed $ch
      *
-     * @return string query string formatted parameters
+     * @return mixed
      */
-    public function toQueryString()
+    public function exec($ch)
     {
-        return http_build_query($this->toArray(), '', '&');
+        // @phpstan-ignore argument.type
+        return curl_exec($ch);
     }
 
-    private static function nullableStringValue(mixed $value): ?string
+    /**
+     * @param mixed $ch
+     */
+    public function close($ch): void
     {
-        if (is_null($value)) {
-            return null;
-        }
-
-        return self::stringValue($value);
-    }
-
-    private static function stringValue(mixed $value): string
-    {
-        if (is_scalar($value) || $value instanceof \Stringable) {
-            return (string) $value;
-        }
-
-        return '';
+        // @phpstan-ignore argument.type
+        curl_close($ch);
     }
 }

--- a/src/ReCaptcha/RequestMethod/Curl.php
+++ b/src/ReCaptcha/RequestMethod/Curl.php
@@ -84,7 +84,6 @@ class Curl
      */
     public function close($ch)
     {
-        // @phpstan-ignore argument.type
-        curl_close($ch);
+        // PHP automatically closes curl resources on destruction.
     }
 }

--- a/src/ReCaptcha/RequestMethod/Curl.php
+++ b/src/ReCaptcha/RequestMethod/Curl.php
@@ -57,8 +57,10 @@ class Curl
     /**
      * @param mixed             $ch
      * @param array<int, mixed> $options
+     *
+     * @return bool
      */
-    public function setoptArray($ch, array $options): bool
+    public function setoptArray($ch, array $options)
     {
         // @phpstan-ignore argument.type
         return curl_setopt_array($ch, $options);
@@ -77,8 +79,10 @@ class Curl
 
     /**
      * @param mixed $ch
+     *
+     * @phpstan-return void
      */
-    public function close($ch): void
+    public function close($ch)
     {
         // @phpstan-ignore argument.type
         curl_close($ch);

--- a/src/ReCaptcha/RequestMethod/Curl.php
+++ b/src/ReCaptcha/RequestMethod/Curl.php
@@ -74,12 +74,9 @@ class Curl
     /**
      * @see http://php.net/curl_exec
      *
-     * Note: always used with CURLOPT_RETURNTRANSFER set, so this returns the
-     * response body as a string on success, or false on failure.
-     *
      * @param \CurlHandle|false $ch
      *
-     * @return false|string
+     * @return bool|string
      */
     public function exec($ch)
     {
@@ -87,8 +84,6 @@ class Curl
             return false;
         }
 
-        $result = curl_exec($ch);
-
-        return true === $result ? false : $result;
+        return curl_exec($ch);
     }
 }

--- a/src/ReCaptcha/RequestMethod/Curl.php
+++ b/src/ReCaptcha/RequestMethod/Curl.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -45,9 +43,11 @@ namespace ReCaptcha\RequestMethod;
 class Curl
 {
     /**
-     * @param null|string $url
+     * @see http://php.net/curl_init
      *
-     * @return mixed
+     * @param string $url
+     *
+     * @return \CurlHandle|false cURL handle
      */
     public function init($url = null)
     {
@@ -55,35 +55,40 @@ class Curl
     }
 
     /**
-     * @param mixed             $ch
-     * @param array<int, mixed> $options
+     * @see http://php.net/curl_setopt_array
+     *
+     * @param \CurlHandle|false        $ch
+     * @param array<int|string, mixed> $options
      *
      * @return bool
      */
     public function setoptArray($ch, array $options)
     {
-        // @phpstan-ignore argument.type
+        if (false === $ch) {
+            return false;
+        }
+
         return curl_setopt_array($ch, $options);
     }
 
     /**
-     * @param mixed $ch
+     * @see http://php.net/curl_exec
      *
-     * @return mixed
+     * Note: always used with CURLOPT_RETURNTRANSFER set, so this returns the
+     * response body as a string on success, or false on failure.
+     *
+     * @param \CurlHandle|false $ch
+     *
+     * @return false|string
      */
     public function exec($ch)
     {
-        // @phpstan-ignore argument.type
-        return curl_exec($ch);
-    }
+        if (false === $ch) {
+            return false;
+        }
 
-    /**
-     * @param mixed $ch
-     *
-     * @phpstan-return void
-     */
-    public function close($ch)
-    {
-        // PHP automatically closes curl resources on destruction.
+        $result = curl_exec($ch);
+
+        return true === $result ? false : $result;
     }
 }

--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -51,6 +51,8 @@ use ReCaptcha\RequestParameters;
  */
 class CurlPost implements RequestMethod
 {
+    private Curl $curl;
+
     /**
      * URL for reCAPTCHA siteverify API.
      */
@@ -59,11 +61,19 @@ class CurlPost implements RequestMethod
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|string $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param null|Curl|string $curlOrSiteVerifyUrl Curl wrapper or URL for reCAPTCHA siteverify API
+     * @param null|string      $siteVerifyUrl       URL for reCAPTCHA siteverify API
      */
-    public function __construct(?string $siteVerifyUrl = null)
+    public function __construct($curlOrSiteVerifyUrl = null, $siteVerifyUrl = null)
     {
-        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
+        if ($curlOrSiteVerifyUrl instanceof Curl) {
+            $this->curl = $curlOrSiteVerifyUrl;
+        } else {
+            $this->curl = new Curl();
+            $siteVerifyUrl = $curlOrSiteVerifyUrl ?? $siteVerifyUrl;
+        }
+
+        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : (string) $siteVerifyUrl;
     }
 
     /**
@@ -73,9 +83,9 @@ class CurlPost implements RequestMethod
      *
      * @return string Body of the reCAPTCHA response
      */
-    public function submit(RequestParameters $params): string
+    public function submit(RequestParameters $params)
     {
-        $handle = curl_init($this->siteVerifyUrl);
+        $handle = $this->curl->init($this->siteVerifyUrl);
 
         $options = [
             CURLOPT_POST => true,
@@ -89,10 +99,10 @@ class CurlPost implements RequestMethod
             CURLOPT_SSL_VERIFYPEER => true,
             CURLOPT_TIMEOUT => 60,
         ];
-        curl_setopt_array($handle, $options);
+        $this->curl->setoptArray($handle, $options);
 
         try {
-            $response = curl_exec($handle);
+            $response = $this->curl->exec($handle);
 
             if (is_string($response)) {
                 return $response;
@@ -100,7 +110,7 @@ class CurlPost implements RequestMethod
 
             return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
         } finally {
-            curl_close($handle);
+            $this->curl->close($handle);
         }
     }
 }

--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -61,16 +61,16 @@ class CurlPost implements RequestMethod
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|Curl|string $curlOrSiteVerifyUrl Curl wrapper or URL for reCAPTCHA siteverify API
-     * @param null|string      $siteVerifyUrl       URL for reCAPTCHA siteverify API
+     * @param null|Curl|string $curl          Curl wrapper or URL for reCAPTCHA siteverify API
+     * @param null|string      $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct($curlOrSiteVerifyUrl = null, $siteVerifyUrl = null)
+    public function __construct($curl = null, $siteVerifyUrl = null)
     {
-        if ($curlOrSiteVerifyUrl instanceof Curl) {
-            $this->curl = $curlOrSiteVerifyUrl;
+        if ($curl instanceof Curl) {
+            $this->curl = $curl;
         } else {
             $this->curl = new Curl();
-            $siteVerifyUrl = $curlOrSiteVerifyUrl ?? $siteVerifyUrl;
+            $siteVerifyUrl = $curl ?? $siteVerifyUrl;
         }
 
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : (string) $siteVerifyUrl;

--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -102,7 +102,7 @@ class CurlPost implements RequestMethod
 
         $response = $this->curl->exec($handle);
 
-        if (false !== $response) {
+        if (is_string($response)) {
             return $response;
         }
 

--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -51,29 +49,30 @@ use ReCaptcha\RequestParameters;
  */
 class CurlPost implements RequestMethod
 {
-    private Curl $curl;
+    /**
+     * Curl connection to the reCAPTCHA service.
+     *
+     * @var Curl
+     */
+    private $curl;
 
     /**
      * URL for reCAPTCHA siteverify API.
+     *
+     * @var string
      */
-    private string $siteVerifyUrl;
+    private $siteVerifyUrl;
 
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|Curl|string $curl          Curl wrapper or URL for reCAPTCHA siteverify API
-     * @param null|string      $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param Curl   $curl          Curl resource
+     * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct($curl = null, $siteVerifyUrl = null)
+    public function __construct(?Curl $curl = null, $siteVerifyUrl = null)
     {
-        if ($curl instanceof Curl) {
-            $this->curl = $curl;
-        } else {
-            $this->curl = new Curl();
-            $siteVerifyUrl = $curl ?? $siteVerifyUrl;
-        }
-
-        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : (string) $siteVerifyUrl;
+        $this->curl = (is_null($curl)) ? new Curl() : $curl;
+        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
     }
 
     /**
@@ -101,16 +100,12 @@ class CurlPost implements RequestMethod
         ];
         $this->curl->setoptArray($handle, $options);
 
-        try {
-            $response = $this->curl->exec($handle);
+        $response = $this->curl->exec($handle);
 
-            if (is_string($response)) {
-                return $response;
-            }
-
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
-        } finally {
-            $this->curl->close($handle);
+        if (false !== $response) {
+            return $response;
         }
+
+        return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
     }
 }

--- a/src/ReCaptcha/RequestMethod/Post.php
+++ b/src/ReCaptcha/RequestMethod/Post.php
@@ -58,9 +58,9 @@ class Post implements RequestMethod
      *
      * @param null|string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(?string $siteVerifyUrl = null)
+    public function __construct($siteVerifyUrl = null)
     {
-        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
+        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : (string) $siteVerifyUrl;
     }
 
     /**
@@ -70,7 +70,7 @@ class Post implements RequestMethod
      *
      * @return string Body of the reCAPTCHA response
      */
-    public function submit(RequestParameters $params): string
+    public function submit(RequestParameters $params)
     {
         $options = [
             'ssl' => [

--- a/src/ReCaptcha/RequestMethod/Post.php
+++ b/src/ReCaptcha/RequestMethod/Post.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -50,17 +48,19 @@ class Post implements RequestMethod
 {
     /**
      * URL for reCAPTCHA siteverify API.
+     *
+     * @var string
      */
-    private string $siteVerifyUrl;
+    private $siteVerifyUrl;
 
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|string $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
     public function __construct($siteVerifyUrl = null)
     {
-        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : (string) $siteVerifyUrl;
+        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
     }
 
     /**
@@ -73,21 +73,21 @@ class Post implements RequestMethod
     public function submit(RequestParameters $params)
     {
         $options = [
-            'ssl' => [
-                'verify_peer' => true,
-                'verify_peer_name' => true,
-            ],
             'http' => [
                 'header' => "Content-type: application/x-www-form-urlencoded\r\n",
                 'method' => 'POST',
                 'content' => $params->toQueryString(),
                 'timeout' => 60,
             ],
+            'ssl' => [
+                'verify_peer' => true,
+                'verify_peer_name' => true,
+            ],
         ];
         $context = stream_context_create($options);
         $response = file_get_contents($this->siteVerifyUrl, false, $context);
 
-        if (is_string($response)) {
+        if (false !== $response) {
             return $response;
         }
 

--- a/src/ReCaptcha/RequestMethod/Socket.php
+++ b/src/ReCaptcha/RequestMethod/Socket.php
@@ -37,82 +37,64 @@ declare(strict_types=1);
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace ReCaptcha;
+namespace ReCaptcha\RequestMethod;
 
 /**
- * Stores and formats the parameters for the request to the reCAPTCHA service.
+ * Convenience wrapper around native socket and stream functions to allow mocking.
  */
-class RequestParameters
+class Socket
 {
-    private string $secret;
-
-    private string $response;
-
-    private ?string $remoteIp;
-
-    private ?string $version;
+    /**
+     * @var mixed
+     */
+    private $handle;
 
     /**
-     * Initialise parameters.
+     * @param string     $hostname
+     * @param int        $port
+     * @param int        $errno
+     * @param string     $errstr
+     * @param null|float $timeout
      *
-     * @param mixed $secret   site secret
-     * @param mixed $response value from g-captcha-response form field
-     * @param mixed $remoteIp user's IP address
-     * @param mixed $version  version of this client library
+     * @return mixed
      */
-    public function __construct($secret, $response, $remoteIp = null, $version = null)
+    public function fsockopen($hostname, $port = -1, &$errno = 0, &$errstr = '', $timeout = null)
     {
-        $this->secret = self::stringValue($secret);
-        $this->response = self::stringValue($response);
-        $this->remoteIp = self::nullableStringValue($remoteIp);
-        $this->version = self::nullableStringValue($version);
-    }
+        $timeout = is_null($timeout) ? floatval(ini_get('default_socket_timeout')) : $timeout;
+        $this->handle = fsockopen($hostname, $port, $errno, $errstr, $timeout);
 
-    /**
-     * Array representation.
-     *
-     * @return array<string, string> array formatted parameters
-     */
-    public function toArray()
-    {
-        $params = ['secret' => $this->secret, 'response' => $this->response];
-
-        if (!is_null($this->remoteIp)) {
-            $params['remoteip'] = $this->remoteIp;
+        if (false !== $this->handle && 0 === $errno && '' === $errstr) {
+            return $this->handle;
         }
 
-        if (!is_null($this->version)) {
-            $params['version'] = $this->version;
+        if (false !== $this->handle) {
+            $this->fclose();
         }
 
-        return $params;
+        return false;
     }
 
-    /**
-     * Query string representation for HTTP request.
-     *
-     * @return string query string formatted parameters
-     */
-    public function toQueryString()
+    public function streamSetTimeout(int $seconds): bool
     {
-        return http_build_query($this->toArray(), '', '&');
+        // @phpstan-ignore argument.type
+        return stream_set_timeout($this->handle, $seconds);
     }
 
-    private static function nullableStringValue(mixed $value): ?string
+    public function fwrite(string $string): false|int
     {
-        if (is_null($value)) {
-            return null;
-        }
-
-        return self::stringValue($value);
+        // @phpstan-ignore argument.type
+        return fwrite($this->handle, $string);
     }
 
-    private static function stringValue(mixed $value): string
+    public function streamGetContents(): false|string
     {
-        if (is_scalar($value) || $value instanceof \Stringable) {
-            return (string) $value;
-        }
+        // @phpstan-ignore argument.type
+        return stream_get_contents($this->handle);
+    }
 
-        return '';
+    public function fclose(): bool
+    {
+        // @phpstan-ignore argument.type
+        return fclose($this->handle);
     }
 }

--- a/src/ReCaptcha/RequestMethod/Socket.php
+++ b/src/ReCaptcha/RequestMethod/Socket.php
@@ -60,10 +60,10 @@ class Socket
      */
     public function fsockopen($hostname, $port = -1, &$errno = 0, &$errstr = '', $timeout = null)
     {
-        $timeout = is_null($timeout) ? floatval(ini_get('default_socket_timeout')) : $timeout;
+        $timeout = is_null($timeout) ? floatval(ini_get('default_socket_timeout')) : floatval($timeout);
         $this->handle = fsockopen($hostname, $port, $errno, $errstr, $timeout);
 
-        if (false !== $this->handle && 0 === $errno && '' === $errstr) {
+        if (false != $this->handle && 0 === $errno && '' === $errstr) {
             return $this->handle;
         }
 
@@ -74,25 +74,80 @@ class Socket
         return false;
     }
 
-    public function streamSetTimeout(int $seconds): bool
+    /**
+     * @param int $seconds
+     * @param int $microseconds
+     *
+     * @return bool
+     */
+    public function streamSetTimeout($seconds, $microseconds = 0)
     {
         // @phpstan-ignore argument.type
-        return stream_set_timeout($this->handle, $seconds);
+        return stream_set_timeout($this->handle, $seconds, $microseconds);
     }
 
-    public function fwrite(string $string): false|int
+    /**
+     * @param string   $string
+     * @param null|int $length
+     *
+     * @return false|int
+     */
+    public function fwrite($string, $length = null)
+    {
+        $string = (string) $string;
+
+        // @phpstan-ignore argument.type
+        return fwrite($this->handle, $string, is_null($length) ? strlen($string) : $length);
+    }
+
+    /**
+     * @param null|int $length
+     * @param int      $offset
+     *
+     * @return false|string
+     */
+    public function streamGetContents($length = null, $offset = -1)
+    {
+        if (is_null($length)) {
+            // @phpstan-ignore argument.type
+            return stream_get_contents($this->handle);
+        }
+
+        // @phpstan-ignore argument.type
+        return stream_get_contents($this->handle, $length, $offset);
+    }
+
+    /**
+     * @param null|int $length
+     *
+     * @return false|string
+     */
+    public function fgets($length = null)
+    {
+        if (is_null($length)) {
+            // @phpstan-ignore argument.type
+            return fgets($this->handle);
+        }
+
+        $length = max(0, intval($length));
+
+        // @phpstan-ignore argument.type
+        return fgets($this->handle, $length);
+    }
+
+    /**
+     * @return bool
+     */
+    public function feof()
     {
         // @phpstan-ignore argument.type
-        return fwrite($this->handle, $string);
+        return feof($this->handle);
     }
 
-    public function streamGetContents(): false|string
-    {
-        // @phpstan-ignore argument.type
-        return stream_get_contents($this->handle);
-    }
-
-    public function fclose(): bool
+    /**
+     * @return bool
+     */
+    public function fclose()
     {
         // @phpstan-ignore argument.type
         return fclose($this->handle);

--- a/src/ReCaptcha/RequestMethod/Socket.php
+++ b/src/ReCaptcha/RequestMethod/Socket.php
@@ -67,6 +67,13 @@ class Socket
         $this->handle = fsockopen($hostname, $port, $errno, $errstr, $resolvedTimeout);
 
         if (false != $this->handle && 0 === $errno && '' === $errstr) {
+            // The timeout above only covers making the connection. Without
+            // this, reads fall back to default_socket_timeout, which a host is
+            // free to set to never time out at all, so a connection that
+            // stalled midway through the response would block the caller
+            // indefinitely.
+            stream_set_timeout($this->handle, (int) $resolvedTimeout);
+
             return $this->handle;
         }
 
@@ -101,18 +108,17 @@ class Socket
      *
      * @param int $length
      *
-     * @return string
+     * @return false|string
      */
     public function fgets($length = null)
     {
         if (false === $this->handle || null === $this->handle) {
-            return '';
+            return false;
         }
 
         $resolvedLength = is_null($length) ? null : max(0, $length);
-        $line = fgets($this->handle, $resolvedLength);
 
-        return false === $line ? '' : $line;
+        return fgets($this->handle, $resolvedLength);
     }
 
     /**

--- a/src/ReCaptcha/RequestMethod/Socket.php
+++ b/src/ReCaptcha/RequestMethod/Socket.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -40,116 +38,112 @@ declare(strict_types=1);
 namespace ReCaptcha\RequestMethod;
 
 /**
- * Convenience wrapper around native socket and stream functions to allow mocking.
+ * Convenience wrapper around native socket and file functions to allow for
+ * mocking.
  */
 class Socket
 {
     /**
-     * @var mixed
+     * @var null|false|resource
      */
     private $handle;
 
     /**
-     * @param string     $hostname
-     * @param int        $port
-     * @param int        $errno
-     * @param string     $errstr
-     * @param null|float $timeout
+     * fsockopen.
      *
-     * @return mixed
+     * @see http://php.net/fsockopen
+     *
+     * @param string $hostname
+     * @param int    $port
+     * @param int    $errno
+     * @param string $errstr
+     * @param float  $timeout
+     *
+     * @return false|resource
      */
     public function fsockopen($hostname, $port = -1, &$errno = 0, &$errstr = '', $timeout = null)
     {
-        $timeout = is_null($timeout) ? floatval(ini_get('default_socket_timeout')) : floatval($timeout);
-        $this->handle = fsockopen($hostname, $port, $errno, $errstr, $timeout);
+        $resolvedTimeout = is_null($timeout) ? (float) ini_get('default_socket_timeout') : $timeout;
+        $this->handle = fsockopen($hostname, $port, $errno, $errstr, $resolvedTimeout);
 
         if (false != $this->handle && 0 === $errno && '' === $errstr) {
             return $this->handle;
-        }
-
-        if (false !== $this->handle) {
-            $this->fclose();
         }
 
         return false;
     }
 
     /**
-     * @param int $seconds
-     * @param int $microseconds
+     * fwrite.
      *
-     * @return bool
-     */
-    public function streamSetTimeout($seconds, $microseconds = 0)
-    {
-        // @phpstan-ignore argument.type
-        return stream_set_timeout($this->handle, $seconds, $microseconds);
-    }
-
-    /**
-     * @param string   $string
-     * @param null|int $length
+     * @see http://php.net/fwrite
      *
-     * @return false|int
+     * @param string $string
+     * @param int    $length
+     *
+     * @return bool|int
      */
     public function fwrite($string, $length = null)
     {
-        $string = (string) $string;
-
-        // @phpstan-ignore argument.type
-        return fwrite($this->handle, $string, is_null($length) ? strlen($string) : $length);
-    }
-
-    /**
-     * @param null|int $length
-     * @param int      $offset
-     *
-     * @return false|string
-     */
-    public function streamGetContents($length = null, $offset = -1)
-    {
-        if (is_null($length)) {
-            // @phpstan-ignore argument.type
-            return stream_get_contents($this->handle);
+        if (false === $this->handle || null === $this->handle) {
+            return false;
         }
 
-        // @phpstan-ignore argument.type
-        return stream_get_contents($this->handle, $length, $offset);
+        $resolvedLength = is_null($length) ? strlen($string) : max(0, $length);
+
+        return fwrite($this->handle, $string, $resolvedLength);
     }
 
     /**
-     * @param null|int $length
+     * fgets.
      *
-     * @return false|string
+     * @see http://php.net/fgets
+     *
+     * @param int $length
+     *
+     * @return string
      */
     public function fgets($length = null)
     {
-        if (is_null($length)) {
-            // @phpstan-ignore argument.type
-            return fgets($this->handle);
+        if (false === $this->handle || null === $this->handle) {
+            return '';
         }
 
-        $length = max(0, intval($length));
+        $resolvedLength = is_null($length) ? null : max(0, $length);
+        $line = fgets($this->handle, $resolvedLength);
 
-        // @phpstan-ignore argument.type
-        return fgets($this->handle, $length);
+        return false === $line ? '' : $line;
     }
 
     /**
+     * feof.
+     *
+     * @see http://php.net/feof
+     *
      * @return bool
      */
     public function feof()
     {
-        // @phpstan-ignore argument.type
+        if (false === $this->handle || null === $this->handle) {
+            return true;
+        }
+
         return feof($this->handle);
     }
 
     /**
+     * fclose.
+     *
+     * @see http://php.net/fclose
+     *
      * @return bool
      */
     public function fclose()
     {
-        // @phpstan-ignore argument.type
+        if (false === $this->handle || null === $this->handle) {
+            return false;
+        }
+
         return fclose($this->handle);
     }
 }

--- a/src/ReCaptcha/RequestMethod/SocketPost.php
+++ b/src/ReCaptcha/RequestMethod/SocketPost.php
@@ -57,16 +57,16 @@ class SocketPost implements RequestMethod
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|Socket|string $socketOrSiteVerifyUrl Socket wrapper or URL for reCAPTCHA siteverify API
-     * @param null|string        $siteVerifyUrl         URL for reCAPTCHA siteverify API
+     * @param null|Socket|string $socket        Socket wrapper or URL for reCAPTCHA siteverify API
+     * @param null|string        $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct($socketOrSiteVerifyUrl = null, $siteVerifyUrl = null)
+    public function __construct($socket = null, $siteVerifyUrl = null)
     {
-        if ($socketOrSiteVerifyUrl instanceof Socket) {
-            $this->socket = $socketOrSiteVerifyUrl;
+        if ($socket instanceof Socket) {
+            $this->socket = $socket;
         } else {
             $this->socket = new Socket();
-            $siteVerifyUrl = $socketOrSiteVerifyUrl ?? $siteVerifyUrl;
+            $siteVerifyUrl = $socket ?? $siteVerifyUrl;
         }
 
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : (string) $siteVerifyUrl;

--- a/src/ReCaptcha/RequestMethod/SocketPost.php
+++ b/src/ReCaptcha/RequestMethod/SocketPost.php
@@ -45,8 +45,8 @@ use ReCaptcha\RequestParameters;
 
 /**
  * Sends a POST request to the reCAPTCHA service, but makes use of fsockopen()
- * instead of get_file_contents(). This is to account for people who may be on
- * servers where allow_url_open is disabled.
+ * instead of file_get_contents(). This is to account for people who may be on
+ * servers where allow_url_fopen is disabled.
  */
 class SocketPost implements RequestMethod
 {

--- a/src/ReCaptcha/RequestMethod/SocketPost.php
+++ b/src/ReCaptcha/RequestMethod/SocketPost.php
@@ -50,16 +50,26 @@ use ReCaptcha\RequestParameters;
  */
 class SocketPost implements RequestMethod
 {
+    private Socket $socket;
+
     private string $siteVerifyUrl;
 
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|string $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param null|Socket|string $socketOrSiteVerifyUrl Socket wrapper or URL for reCAPTCHA siteverify API
+     * @param null|string        $siteVerifyUrl         URL for reCAPTCHA siteverify API
      */
-    public function __construct(?string $siteVerifyUrl = null)
+    public function __construct($socketOrSiteVerifyUrl = null, $siteVerifyUrl = null)
     {
-        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
+        if ($socketOrSiteVerifyUrl instanceof Socket) {
+            $this->socket = $socketOrSiteVerifyUrl;
+        } else {
+            $this->socket = new Socket();
+            $siteVerifyUrl = $socketOrSiteVerifyUrl ?? $siteVerifyUrl;
+        }
+
+        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : (string) $siteVerifyUrl;
     }
 
     /**
@@ -69,7 +79,7 @@ class SocketPost implements RequestMethod
      *
      * @return string Body of the reCAPTCHA response
      */
-    public function submit(RequestParameters $params): string
+    public function submit(RequestParameters $params)
     {
         $errno = 0;
         $errstr = '';
@@ -79,13 +89,15 @@ class SocketPost implements RequestMethod
             return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
         }
 
-        $handle = fsockopen('ssl://'.$urlParsed['host'], 443, $errno, $errstr, 30);
+        $handle = $this->socket->fsockopen('ssl://'.$urlParsed['host'], 443, $errno, $errstr, 30);
 
         if (false === $handle || 0 !== $errno || '' !== $errstr) {
             return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
         }
 
-        if (false === stream_set_timeout($handle, 60)) {
+        if (false === $this->socket->streamSetTimeout(60)) {
+            $this->socket->fclose();
+
             return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
         }
 
@@ -98,10 +110,10 @@ class SocketPost implements RequestMethod
         $request .= "Connection: close\r\n\r\n";
         $request .= $content."\r\n\r\n";
 
-        fwrite($handle, $request);
-        $response = stream_get_contents($handle);
+        $this->socket->fwrite($request);
+        $response = $this->socket->streamGetContents();
 
-        fclose($handle);
+        $this->socket->fclose();
 
         if (!is_string($response)) {
             $response = '';

--- a/src/ReCaptcha/RequestMethod/SocketPost.php
+++ b/src/ReCaptcha/RequestMethod/SocketPost.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -45,31 +43,35 @@ use ReCaptcha\RequestParameters;
 
 /**
  * Sends a POST request to the reCAPTCHA service, but makes use of fsockopen()
- * instead of file_get_contents(). This is to account for people who may be on
- * servers where allow_url_fopen is disabled.
+ * instead of get_file_contents(). This is to account for people who may be on
+ * servers where allow_url_open is disabled.
  */
 class SocketPost implements RequestMethod
 {
-    private Socket $socket;
+    /**
+     * Socket to the reCAPTCHA service.
+     *
+     * @var Socket
+     */
+    private $socket;
 
-    private string $siteVerifyUrl;
+    /**
+     * URL for reCAPTCHA siteverify API.
+     *
+     * @var string
+     */
+    private $siteVerifyUrl;
 
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|Socket|string $socket        Socket wrapper or URL for reCAPTCHA siteverify API
-     * @param null|string        $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param Socket $socket        optional socket, injectable for testing
+     * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct($socket = null, $siteVerifyUrl = null)
+    public function __construct(?Socket $socket = null, $siteVerifyUrl = null)
     {
-        if ($socket instanceof Socket) {
-            $this->socket = $socket;
-        } else {
-            $this->socket = new Socket();
-            $siteVerifyUrl = $socket ?? $siteVerifyUrl;
-        }
-
-        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : (string) $siteVerifyUrl;
+        $this->socket = (is_null($socket)) ? new Socket() : $socket;
+        $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
     }
 
     /**
@@ -85,19 +87,11 @@ class SocketPost implements RequestMethod
         $errstr = '';
         $urlParsed = parse_url($this->siteVerifyUrl);
 
-        if (false === $urlParsed || !isset($urlParsed['host']) || !isset($urlParsed['path'])) {
+        if (false === $urlParsed || !isset($urlParsed['host'], $urlParsed['path'])) {
             return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
         }
 
-        $handle = $this->socket->fsockopen('ssl://'.$urlParsed['host'], 443, $errno, $errstr, 30);
-
-        if (false === $handle || 0 !== $errno || '' !== $errstr) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
-        }
-
-        if (false === $this->socket->streamSetTimeout(60)) {
-            $this->socket->fclose();
-
+        if (false === $this->socket->fsockopen('ssl://'.$urlParsed['host'], 443, $errno, $errstr, 30)) {
             return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
         }
 
@@ -111,13 +105,13 @@ class SocketPost implements RequestMethod
         $request .= $content."\r\n\r\n";
 
         $this->socket->fwrite($request);
-        $response = $this->socket->streamGetContents();
+        $response = '';
+
+        while (!$this->socket->feof()) {
+            $response .= $this->socket->fgets(4096);
+        }
 
         $this->socket->fclose();
-
-        if (!is_string($response)) {
-            $response = '';
-        }
 
         if (1 !== preg_match('#^HTTP/1\.[01] 200 OK#', $response)) {
             return '{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}';

--- a/src/ReCaptcha/RequestParameters.php
+++ b/src/ReCaptcha/RequestParameters.php
@@ -55,10 +55,10 @@ class RequestParameters
     /**
      * Initialise parameters.
      *
-     * @param mixed $secret   site secret
-     * @param mixed $response value from g-captcha-response form field
-     * @param mixed $remoteIp user's IP address
-     * @param mixed $version  version of this client library
+     * @param string      $secret   site secret
+     * @param string      $response value from g-recaptcha-response form field
+     * @param null|string $remoteIp user's IP address
+     * @param null|string $version  version of this client library
      */
     public function __construct($secret, $response, $remoteIp = null, $version = null)
     {

--- a/src/ReCaptcha/RequestParameters.php
+++ b/src/ReCaptcha/RequestParameters.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -44,28 +42,48 @@ namespace ReCaptcha;
  */
 class RequestParameters
 {
-    private string $secret;
+    /**
+     * The shared key between your site and reCAPTCHA.
+     *
+     * @var string
+     */
+    private $secret;
 
-    private string $response;
+    /**
+     * The user response token provided by reCAPTCHA, verifying the user on your site.
+     *
+     * @var string
+     */
+    private $response;
 
-    private ?string $remoteIp;
+    /**
+     * Remote user's IP address.
+     *
+     * @var null|string
+     */
+    private $remoteIp;
 
-    private ?string $version;
+    /**
+     * Client version.
+     *
+     * @var null|string
+     */
+    private $version;
 
     /**
      * Initialise parameters.
      *
-     * @param string      $secret   site secret
-     * @param string      $response value from g-recaptcha-response form field
-     * @param null|string $remoteIp user's IP address
-     * @param null|string $version  version of this client library
+     * @param string $secret   site secret
+     * @param string $response value from g-captcha-response form field
+     * @param string $remoteIp user's IP address
+     * @param string $version  version of this client library
      */
     public function __construct($secret, $response, $remoteIp = null, $version = null)
     {
-        $this->secret = self::stringValue($secret);
-        $this->response = self::stringValue($response);
-        $this->remoteIp = self::nullableStringValue($remoteIp);
-        $this->version = self::nullableStringValue($version);
+        $this->secret = $secret;
+        $this->response = $response;
+        $this->remoteIp = $remoteIp;
+        $this->version = $version;
     }
 
     /**
@@ -96,23 +114,5 @@ class RequestParameters
     public function toQueryString()
     {
         return http_build_query($this->toArray(), '', '&');
-    }
-
-    private static function nullableStringValue(mixed $value): ?string
-    {
-        if (is_null($value)) {
-            return null;
-        }
-
-        return self::stringValue($value);
-    }
-
-    private static function stringValue(mixed $value): string
-    {
-        if (is_scalar($value) || $value instanceof \Stringable) {
-            return (string) $value;
-        }
-
-        return '';
     }
 }

--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -76,11 +76,11 @@ class Response
     {
         $this->success = (bool) $success;
         $this->errorCodes = $errorCodes;
-        $this->hostname = (string) $hostname;
-        $this->challengeTs = (string) $challengeTs;
-        $this->apkPackageName = (string) $apkPackageName;
-        $this->score = is_null($score) ? null : floatval($score);
-        $this->action = (string) $action;
+        $this->hostname = self::stringValue($hostname);
+        $this->challengeTs = self::stringValue($challengeTs);
+        $this->apkPackageName = self::stringValue($apkPackageName);
+        $this->score = self::nullableFloatValue($score);
+        $this->action = self::stringValue($action);
     }
 
     /**
@@ -98,17 +98,17 @@ class Response
 
         $responseData = json_decode($json, true);
 
-        if (!is_array($responseData)) {
+        if (!$responseData || !is_array($responseData)) {
             return new Response(false, [ReCaptcha::E_INVALID_JSON]);
         }
 
-        $hostname = isset($responseData['hostname']) && is_string($responseData['hostname']) ? $responseData['hostname'] : '';
-        $challengeTs = isset($responseData['challenge_ts']) && is_string($responseData['challenge_ts']) ? $responseData['challenge_ts'] : '';
-        $apkPackageName = isset($responseData['apk_package_name']) && is_string($responseData['apk_package_name']) ? $responseData['apk_package_name'] : '';
-        $score = isset($responseData['score']) && is_numeric($responseData['score']) ? floatval($responseData['score']) : null;
-        $action = isset($responseData['action']) && is_string($responseData['action']) ? $responseData['action'] : '';
+        $hostname = self::stringValue($responseData['hostname'] ?? '');
+        $challengeTs = self::stringValue($responseData['challenge_ts'] ?? '');
+        $apkPackageName = self::stringValue($responseData['apk_package_name'] ?? '');
+        $score = self::nullableFloatValue($responseData['score'] ?? null);
+        $action = self::stringValue($responseData['action'] ?? '');
 
-        if (isset($responseData['success']) && true === $responseData['success']) {
+        if (isset($responseData['success']) && true == $responseData['success']) {
             return new Response(true, [], $hostname, $challengeTs, $apkPackageName, $score, $action);
         }
 
@@ -216,5 +216,27 @@ class Response
             'action' => $this->getAction(),
             'error-codes' => $this->getErrorCodes(),
         ];
+    }
+
+    private static function stringValue(mixed $value): string
+    {
+        if (is_scalar($value) || $value instanceof \Stringable) {
+            return (string) $value;
+        }
+
+        return '';
+    }
+
+    private static function nullableFloatValue(mixed $value): ?float
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        if (is_scalar($value)) {
+            return floatval($value);
+        }
+
+        return null;
     }
 }

--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -42,8 +42,25 @@ namespace ReCaptcha;
 /**
  * The response returned from the service.
  */
-readonly class Response
+class Response
 {
+    private bool $success = false;
+
+    /**
+     * @var array<string>
+     */
+    private array $errorCodes = [];
+
+    private string $hostname = '';
+
+    private string $challengeTs = '';
+
+    private string $apkPackageName = '';
+
+    private ?float $score = null;
+
+    private string $action = '';
+
     /**
      * Constructor.
      *
@@ -55,21 +72,30 @@ readonly class Response
      * @param ?float        $score          score assigned to the request
      * @param string        $action         action as specified by the page
      */
-    public function __construct(
-        private bool $success,
-        private array $errorCodes = [],
-        private string $hostname = '',
-        private string $challengeTs = '',
-        private string $apkPackageName = '',
-        private ?float $score = null,
-        private string $action = '',
-    ) {}
+    public function __construct($success, array $errorCodes = [], $hostname = '', $challengeTs = '', $apkPackageName = '', $score = null, $action = '')
+    {
+        $this->success = (bool) $success;
+        $this->errorCodes = $errorCodes;
+        $this->hostname = (string) $hostname;
+        $this->challengeTs = (string) $challengeTs;
+        $this->apkPackageName = (string) $apkPackageName;
+        $this->score = is_null($score) ? null : floatval($score);
+        $this->action = (string) $action;
+    }
 
     /**
      * Build the response from the expected JSON returned by the service.
+     *
+     * @param mixed $json
+     *
+     * @return Response
      */
-    public static function fromJson(string $json): Response
+    public static function fromJson($json)
     {
+        if (!is_string($json)) {
+            return new Response(false, [ReCaptcha::E_INVALID_JSON]);
+        }
+
         $responseData = json_decode($json, true);
 
         if (!is_array($responseData)) {
@@ -98,8 +124,10 @@ readonly class Response
 
     /**
      * Is success?
+     *
+     * @return bool
      */
-    public function isSuccess(): bool
+    public function isSuccess()
     {
         return $this->success;
     }
@@ -109,47 +137,57 @@ readonly class Response
      *
      * @return array<string>
      */
-    public function getErrorCodes(): array
+    public function getErrorCodes()
     {
         return $this->errorCodes;
     }
 
     /**
      * Get hostname.
+     *
+     * @return string
      */
-    public function getHostname(): string
+    public function getHostname()
     {
         return $this->hostname;
     }
 
     /**
      * Get challenge timestamp.
+     *
+     * @return string
      */
-    public function getChallengeTs(): string
+    public function getChallengeTs()
     {
         return $this->challengeTs;
     }
 
     /**
      * Get APK package name.
+     *
+     * @return string
      */
-    public function getApkPackageName(): string
+    public function getApkPackageName()
     {
         return $this->apkPackageName;
     }
 
     /**
      * Get score.
+     *
+     * @return null|float
      */
-    public function getScore(): ?float
+    public function getScore()
     {
         return $this->score;
     }
 
     /**
      * Get action.
+     *
+     * @return string
      */
-    public function getAction(): string
+    public function getAction()
     {
         return $this->action;
     }
@@ -167,7 +205,7 @@ readonly class Response
      *     error-codes: string[]
      * }
      */
-    public function toArray(): array
+    public function toArray()
     {
         return [
             'success' => $this->isSuccess(),

--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -44,77 +42,104 @@ namespace ReCaptcha;
  */
 class Response
 {
-    private bool $success = false;
+    /**
+     * Success or failure.
+     *
+     * @var bool
+     */
+    private $success = false;
 
     /**
-     * @var array<string>
+     * Error code strings.
+     *
+     * @var array<int, string>
      */
-    private array $errorCodes = [];
+    private $errorCodes = [];
 
-    private string $hostname = '';
+    /**
+     * The hostname of the site where the reCAPTCHA was solved.
+     *
+     * @var string
+     */
+    private $hostname;
 
-    private string $challengeTs = '';
+    /**
+     * Timestamp of the challenge load (ISO format yyyy-MM-dd'T'HH:mm:ssZZ).
+     *
+     * @var string
+     */
+    private $challengeTs;
 
-    private string $apkPackageName = '';
+    /**
+     * APK package name.
+     *
+     * @var string
+     */
+    private $apkPackageName;
 
-    private ?float $score = null;
+    /**
+     * Score assigned to the request.
+     *
+     * @var null|float
+     */
+    private $score;
 
-    private string $action = '';
+    /**
+     * Action as specified by the page.
+     *
+     * @var string
+     */
+    private $action;
 
     /**
      * Constructor.
      *
-     * @param bool          $success        success or failure
-     * @param array<string> $errorCodes     error code strings
-     * @param string        $hostname       the hostname of the site where the reCAPTCHA was solved
-     * @param string        $challengeTs    timestamp of the challenge load (ISO format yyyy-MM-dd'T'HH:mm:ssZZ)
-     * @param string        $apkPackageName APK package name
-     * @param ?float        $score          score assigned to the request
-     * @param string        $action         action as specified by the page
+     * @param bool               $success
+     * @param array<int, string> $errorCodes
+     * @param string             $hostname
+     * @param string             $challengeTs
+     * @param string             $apkPackageName
+     * @param null|float         $score
+     * @param string             $action
      */
     public function __construct($success, array $errorCodes = [], $hostname = '', $challengeTs = '', $apkPackageName = '', $score = null, $action = '')
     {
-        $this->success = (bool) $success;
+        $this->success = $success;
+        $this->hostname = $hostname;
+        $this->challengeTs = $challengeTs;
+        $this->apkPackageName = $apkPackageName;
+        $this->score = $score;
+        $this->action = $action;
         $this->errorCodes = $errorCodes;
-        $this->hostname = self::stringValue($hostname);
-        $this->challengeTs = self::stringValue($challengeTs);
-        $this->apkPackageName = self::stringValue($apkPackageName);
-        $this->score = self::nullableFloatValue($score);
-        $this->action = self::stringValue($action);
     }
 
     /**
      * Build the response from the expected JSON returned by the service.
      *
-     * @param mixed $json
+     * @param string $json
      *
      * @return Response
      */
     public static function fromJson($json)
     {
-        if (!is_string($json)) {
-            return new Response(false, [ReCaptcha::E_INVALID_JSON]);
-        }
-
         $responseData = json_decode($json, true);
 
         if (!$responseData || !is_array($responseData)) {
             return new Response(false, [ReCaptcha::E_INVALID_JSON]);
         }
 
-        $hostname = self::stringValue($responseData['hostname'] ?? '');
-        $challengeTs = self::stringValue($responseData['challenge_ts'] ?? '');
-        $apkPackageName = self::stringValue($responseData['apk_package_name'] ?? '');
-        $score = self::nullableFloatValue($responseData['score'] ?? null);
-        $action = self::stringValue($responseData['action'] ?? '');
+        $hostname = isset($responseData['hostname']) && is_string($responseData['hostname']) ? $responseData['hostname'] : '';
+        $challengeTs = isset($responseData['challenge_ts']) && is_string($responseData['challenge_ts']) ? $responseData['challenge_ts'] : '';
+        $apkPackageName = isset($responseData['apk_package_name']) && is_string($responseData['apk_package_name']) ? $responseData['apk_package_name'] : '';
+        $score = isset($responseData['score']) && is_numeric($responseData['score']) ? floatval($responseData['score']) : null;
+        $action = isset($responseData['action']) && is_string($responseData['action']) ? $responseData['action'] : '';
 
         if (isset($responseData['success']) && true == $responseData['success']) {
             return new Response(true, [], $hostname, $challengeTs, $apkPackageName, $score, $action);
         }
 
         if (isset($responseData['error-codes']) && is_array($responseData['error-codes'])) {
-            /** @var array<string> $errorCodes */
-            $errorCodes = $responseData['error-codes'];
+            $errorCodes = array_values(array_filter($responseData['error-codes'], 'is_string'));
 
             return new Response(false, $errorCodes, $hostname, $challengeTs, $apkPackageName, $score, $action);
         }
@@ -135,7 +160,7 @@ class Response
     /**
      * Get error codes.
      *
-     * @return array<string>
+     * @return array<int, string>
      */
     public function getErrorCodes()
     {
@@ -216,27 +241,5 @@ class Response
             'action' => $this->getAction(),
             'error-codes' => $this->getErrorCodes(),
         ];
-    }
-
-    private static function stringValue(mixed $value): string
-    {
-        if (is_scalar($value) || $value instanceof \Stringable) {
-            return (string) $value;
-        }
-
-        return '';
-    }
-
-    private static function nullableFloatValue(mixed $value): ?float
-    {
-        if (is_null($value)) {
-            return null;
-        }
-
-        if (is_scalar($value)) {
-            return floatval($value);
-        }
-
-        return null;
     }
 }

--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -134,7 +134,7 @@ class Response
         $score = isset($responseData['score']) && is_numeric($responseData['score']) ? floatval($responseData['score']) : null;
         $action = isset($responseData['action']) && is_string($responseData['action']) ? $responseData['action'] : '';
 
-        if (isset($responseData['success']) && true == $responseData['success']) {
+        if (isset($responseData['success']) && true === $responseData['success']) {
             return new Response(true, [], $hostname, $challengeTs, $apkPackageName, $score, $action);
         }
 

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -35,7 +35,7 @@
  */
 
 spl_autoload_register(function ($class) {
-    if (!str_starts_with($class, 'ReCaptcha\\')) {
+    if ('ReCaptcha\\' !== substr($class, 0, 10)) {
         /* If the class does not lie under the "ReCaptcha" namespace,
          * then we can exit immediately.
          */

--- a/tests/ReCaptcha/ReCaptchaTest.php
+++ b/tests/ReCaptcha/ReCaptchaTest.php
@@ -77,9 +77,8 @@ class ReCaptchaTest extends TestCase
     #[DataProvider('invalidSecretProvider')]
     public function testExceptionThrownOnInvalidSecretType(mixed $invalid): void
     {
-        $this->expectException(\TypeError::class);
+        $this->expectException(\RuntimeException::class);
 
-        /** @phpstan-ignore argument.type */
         $rc = new ReCaptcha($invalid);
     }
 
@@ -101,7 +100,6 @@ class ReCaptchaTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
 
-        /** @phpstan-ignore argument.type */
         $rc = new ReCaptcha($emptySecret);
     }
 
@@ -121,6 +119,52 @@ class ReCaptchaTest extends TestCase
         $response = $rc->verify('');
         $this->assertFalse($response->isSuccess());
         $this->assertEquals([ReCaptcha::E_MISSING_INPUT_RESPONSE], $response->getErrorCodes());
+    }
+
+    public function testVerifyReturnsErrorOnNullResponse(): void
+    {
+        $rc = new ReCaptcha('secret');
+        $response = $rc->verify(null);
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals([ReCaptcha::E_MISSING_INPUT_RESPONSE], $response->getErrorCodes());
+    }
+
+    public function testRequestMethodSubmitKeepsLegacyReturnTypeCompatibility(): void
+    {
+        $submit = new \ReflectionMethod(RequestMethod::class, 'submit');
+
+        $this->assertFalse($submit->hasReturnType());
+    }
+
+    public function testLegacyRequestMethodImplementationWithoutReturnTypeCanBeUsed(): void
+    {
+        $method = new class implements RequestMethod {
+            public function submit(RequestParameters $params)
+            {
+                return '{"success": true}';
+            }
+        };
+
+        $rc = new ReCaptcha('secret', $method);
+        $response = $rc->verify('response');
+
+        $this->assertTrue($response->isSuccess());
+    }
+
+    public function testNonStringRequestMethodResponseReturnsBadResponse(): void
+    {
+        $method = new class implements RequestMethod {
+            public function submit(RequestParameters $params)
+            {
+                return false;
+            }
+        };
+
+        $rc = new ReCaptcha('secret', $method);
+        $response = $rc->verify('response');
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals([ReCaptcha::E_BAD_RESPONSE], $response->getErrorCodes());
     }
 
     public function testZeroAsStringIsValidSecret(): void
@@ -254,6 +298,14 @@ class ReCaptchaTest extends TestCase
         $response = $rc->setScoreThreshold(0.5)->verify('response');
         $this->assertFalse($response->isSuccess());
         $this->assertEquals([ReCaptcha::E_SCORE_THRESHOLD_NOT_MET], $response->getErrorCodes());
+    }
+
+    public function testScoreThresholdAcceptsNumericString(): void
+    {
+        $method = $this->getMockRequestMethod('{"success": true, "score": "0.9"}');
+        $rc = new ReCaptcha('secret', $method);
+        $response = $rc->setScoreThreshold('0.5')->verify('response');
+        $this->assertTrue($response->isSuccess());
     }
 
     public function testVerifyWithinTimeout(): void

--- a/tests/ReCaptcha/ReCaptchaTest.php
+++ b/tests/ReCaptcha/ReCaptchaTest.php
@@ -181,6 +181,14 @@ class ReCaptchaTest extends TestCase
         $this->assertTrue($response->isSuccess());
     }
 
+    public function testScalarResponseIsAccepted(): void
+    {
+        $method = $this->getMockRequestMethod('{"success": true}');
+        $rc = new ReCaptcha('secret', $method);
+        $response = $rc->verify(12345);
+        $this->assertTrue($response->isSuccess());
+    }
+
     public function testDefaultRequestMethodWithCurl(): void
     {
         GlobalState::$isCurlAvailable = true;

--- a/tests/ReCaptcha/ReCaptchaTest.php
+++ b/tests/ReCaptcha/ReCaptchaTest.php
@@ -124,20 +124,16 @@ class ReCaptchaTest extends TestCase
     public function testVerifyReturnsErrorOnNullResponse(): void
     {
         $rc = new ReCaptcha('secret');
+
+        /** @phpstan-ignore argument.type */
         $response = $rc->verify(null);
         $this->assertFalse($response->isSuccess());
         $this->assertEquals([ReCaptcha::E_MISSING_INPUT_RESPONSE], $response->getErrorCodes());
     }
 
-    public function testRequestMethodSubmitKeepsLegacyReturnTypeCompatibility(): void
-    {
-        $submit = new \ReflectionMethod(RequestMethod::class, 'submit');
-
-        $this->assertFalse($submit->hasReturnType());
-    }
-
     public function testLegacyRequestMethodImplementationWithoutReturnTypeCanBeUsed(): void
     {
+        // BC: Legacy custom RequestMethod implementations without strict return types should still work
         $method = new class implements RequestMethod {
             public function submit(RequestParameters $params)
             {
@@ -153,9 +149,11 @@ class ReCaptchaTest extends TestCase
 
     public function testNonStringRequestMethodResponseReturnsBadResponse(): void
     {
+        // Keep the 1.x compatibility path open for older custom RequestMethod implementations.
         $method = new class implements RequestMethod {
             public function submit(RequestParameters $params)
             {
+                // @phpstan-ignore return.type
                 return false;
             }
         };
@@ -165,6 +163,17 @@ class ReCaptchaTest extends TestCase
 
         $this->assertFalse($response->isSuccess());
         $this->assertEquals([ReCaptcha::E_BAD_RESPONSE], $response->getErrorCodes());
+    }
+
+    public function testObjectValuesDoNotCrashLegacySetters(): void
+    {
+        $method = $this->getMockRequestMethod('{"success": true, "hostname": ""}');
+        $rc = new ReCaptcha('secret', $method);
+
+        /** @phpstan-ignore argument.type */
+        $response = $rc->setExpectedHostname(new \stdClass())->verify('response');
+
+        $this->assertTrue($response->isSuccess());
     }
 
     public function testZeroAsStringIsValidSecret(): void
@@ -185,6 +194,8 @@ class ReCaptchaTest extends TestCase
     {
         $method = $this->getMockRequestMethod('{"success": true}');
         $rc = new ReCaptcha('secret', $method);
+
+        /** @phpstan-ignore argument.type */
         $response = $rc->verify(12345);
         $this->assertTrue($response->isSuccess());
     }
@@ -312,6 +323,8 @@ class ReCaptchaTest extends TestCase
     {
         $method = $this->getMockRequestMethod('{"success": true, "score": "0.9"}');
         $rc = new ReCaptcha('secret', $method);
+
+        /** @phpstan-ignore argument.type */
         $response = $rc->setScoreThreshold('0.5')->verify('response');
         $this->assertTrue($response->isSuccess());
     }

--- a/tests/ReCaptcha/ReCaptchaTest.php
+++ b/tests/ReCaptcha/ReCaptchaTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -43,42 +41,19 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Global state for mocking functions in the ReCaptcha namespace.
- */
-class GlobalState
-{
-    public static ?bool $isCurlAvailable = null;
-}
-
-/**
- * Mock function_exists in the ReCaptcha namespace.
- */
-function function_exists(string $function): bool
-{
-    if ('curl_version' === $function && !is_null(GlobalState::$isCurlAvailable)) {
-        return GlobalState::$isCurlAvailable;
-    }
-
-    return \function_exists($function);
-}
-
-/**
  * @internal
  *
  * @coversNothing
  */
 class ReCaptchaTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        GlobalState::$isCurlAvailable = null;
-    }
-
+    /**
+     * @param mixed $invalid
+     */
     #[DataProvider('invalidSecretProvider')]
-    public function testExceptionThrownOnInvalidSecretType(mixed $invalid): void
+    public function testExceptionThrownOnInvalidSecret($invalid): void
     {
         $this->expectException(\RuntimeException::class);
-
         $rc = new ReCaptcha($invalid);
     }
 
@@ -88,28 +63,11 @@ class ReCaptchaTest extends TestCase
     public static function invalidSecretProvider(): array
     {
         return [
+            [''],
             [null],
+            [0],
             [new \stdClass()],
             [[]],
-            [0],
-        ];
-    }
-
-    #[DataProvider('emptySecretProvider')]
-    public function testExceptionThrownOnEmptySecret(mixed $emptySecret): void
-    {
-        $this->expectException(\RuntimeException::class);
-
-        $rc = new ReCaptcha($emptySecret);
-    }
-
-    /**
-     * @return array<int, array<int, mixed>>
-     */
-    public static function emptySecretProvider(): array
-    {
-        return [
-            [''],
         ];
     }
 
@@ -121,105 +79,18 @@ class ReCaptchaTest extends TestCase
         $this->assertEquals([ReCaptcha::E_MISSING_INPUT_RESPONSE], $response->getErrorCodes());
     }
 
-    public function testVerifyReturnsErrorOnNullResponse(): void
+    public function testDefaultRequestMethod(): void
     {
-        $rc = new ReCaptcha('secret');
-
-        /** @phpstan-ignore argument.type */
-        $response = $rc->verify(null);
-        $this->assertFalse($response->isSuccess());
-        $this->assertEquals([ReCaptcha::E_MISSING_INPUT_RESPONSE], $response->getErrorCodes());
-    }
-
-    public function testLegacyRequestMethodImplementationWithoutReturnTypeCanBeUsed(): void
-    {
-        // BC: Legacy custom RequestMethod implementations without strict return types should still work
-        $method = new class implements RequestMethod {
-            public function submit(RequestParameters $params)
-            {
-                return '{"success": true}';
-            }
-        };
-
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->verify('response');
-
-        $this->assertTrue($response->isSuccess());
-    }
-
-    public function testNonStringRequestMethodResponseReturnsBadResponse(): void
-    {
-        // Keep the 1.x compatibility path open for older custom RequestMethod implementations.
-        $method = new class implements RequestMethod {
-            public function submit(RequestParameters $params)
-            {
-                // @phpstan-ignore return.type
-                return false;
-            }
-        };
-
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->verify('response');
-
-        $this->assertFalse($response->isSuccess());
-        $this->assertEquals([ReCaptcha::E_BAD_RESPONSE], $response->getErrorCodes());
-    }
-
-    public function testObjectValuesDoNotCrashLegacySetters(): void
-    {
-        $method = $this->getMockRequestMethod('{"success": true, "hostname": ""}');
-        $rc = new ReCaptcha('secret', $method);
-
-        /** @phpstan-ignore argument.type */
-        $response = $rc->setExpectedHostname(new \stdClass())->verify('response');
-
-        $this->assertTrue($response->isSuccess());
-    }
-
-    public function testZeroAsStringIsValidSecret(): void
-    {
-        $rc = new ReCaptcha('0');
-        $this->assertInstanceOf(ReCaptcha::class, $rc);
-    }
-
-    public function testZeroAsStringIsValidResponse(): void
-    {
-        $method = $this->getMockRequestMethod('{"success": true}');
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->verify('0');
-        $this->assertTrue($response->isSuccess());
-    }
-
-    public function testScalarResponseIsAccepted(): void
-    {
-        $method = $this->getMockRequestMethod('{"success": true}');
-        $rc = new ReCaptcha('secret', $method);
-
-        /** @phpstan-ignore argument.type */
-        $response = $rc->verify(12345);
-        $this->assertTrue($response->isSuccess());
-    }
-
-    public function testDefaultRequestMethodWithCurl(): void
-    {
-        GlobalState::$isCurlAvailable = true;
         $rc = new ReCaptcha('secret');
         $reflection = new \ReflectionClass($rc);
         $property = $reflection->getProperty('requestMethod');
         $requestMethod = $property->getValue($rc);
 
-        $this->assertInstanceOf(RequestMethod\CurlPost::class, $requestMethod);
-    }
-
-    public function testDefaultRequestMethodWithoutCurl(): void
-    {
-        GlobalState::$isCurlAvailable = false;
-        $rc = new ReCaptcha('secret');
-        $reflection = new \ReflectionClass($rc);
-        $property = $reflection->getProperty('requestMethod');
-        $requestMethod = $property->getValue($rc);
-
-        $this->assertInstanceOf(RequestMethod\Post::class, $requestMethod);
+        if (function_exists('curl_version')) {
+            $this->assertInstanceOf(RequestMethod\CurlPost::class, $requestMethod);
+        } else {
+            $this->assertInstanceOf(RequestMethod\Post::class, $requestMethod);
+        }
     }
 
     public function testVerifyReturnsResponse(): void
@@ -253,19 +124,6 @@ class ReCaptchaTest extends TestCase
         $response = $rc->setExpectedHostname('host.name')->verify('response');
         $this->assertFalse($response->isSuccess());
         $this->assertEquals([ReCaptcha::E_HOSTNAME_MISMATCH], $response->getErrorCodes());
-    }
-
-    public function testVerifyHostnameMatchCaseInsensitive(): void
-    {
-        $method = $this->getMockRequestMethod('{"success": true, "hostname": "host.name"}');
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setExpectedHostname('HOST.NAME')->verify('response');
-        $this->assertTrue($response->isSuccess());
-
-        $method = $this->getMockRequestMethod('{"success": true, "hostname": "HOST.NAME"}');
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setExpectedHostname('host.name')->verify('response');
-        $this->assertTrue($response->isSuccess());
     }
 
     public function testVerifyApkPackageNameMatch(): void
@@ -306,7 +164,8 @@ class ReCaptchaTest extends TestCase
     {
         $method = $this->getMockRequestMethod('{"success": true, "score": "0.9"}');
         $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setScoreThreshold(0.5)->verify('response');
+        // Passed as a string deliberately: setScoreThreshold() coerces via floatval().
+        $response = $rc->setScoreThreshold('0.5')->verify('response');
         $this->assertTrue($response->isSuccess());
     }
 
@@ -314,19 +173,10 @@ class ReCaptchaTest extends TestCase
     {
         $method = $this->getMockRequestMethod('{"success": true, "score": "0.1"}');
         $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setScoreThreshold(0.5)->verify('response');
+        // Passed as a string deliberately: setScoreThreshold() coerces via floatval().
+        $response = $rc->setScoreThreshold('0.5')->verify('response');
         $this->assertFalse($response->isSuccess());
         $this->assertEquals([ReCaptcha::E_SCORE_THRESHOLD_NOT_MET], $response->getErrorCodes());
-    }
-
-    public function testScoreThresholdAcceptsNumericString(): void
-    {
-        $method = $this->getMockRequestMethod('{"success": true, "score": "0.9"}');
-        $rc = new ReCaptcha('secret', $method);
-
-        /** @phpstan-ignore argument.type */
-        $response = $rc->setScoreThreshold('0.5')->verify('response');
-        $this->assertTrue($response->isSuccess());
     }
 
     public function testVerifyWithinTimeout(): void
@@ -350,19 +200,12 @@ class ReCaptchaTest extends TestCase
         $this->assertEquals([ReCaptcha::E_CHALLENGE_TIMEOUT], $response->getErrorCodes());
     }
 
-    public function testVerifyWithInvalidChallengeTsAndTimeout(): void
-    {
-        $method = $this->getMockRequestMethod('{"success": true, "challenge_ts": "invalid-timestamp"}');
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setChallengeTimeout(60)->verify('response');
-        $this->assertTrue($response->isSuccess());
-    }
-
     public function testVerifyMergesErrors(): void
     {
         $method = $this->getMockRequestMethod('{"success": false, "error-codes": ["initial-error"], "score": "0.1"}');
         $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setScoreThreshold(0.5)->verify('response');
+        // Passed as a string deliberately: setScoreThreshold() coerces via floatval().
+        $response = $rc->setScoreThreshold('0.5')->verify('response');
         $this->assertFalse($response->isSuccess());
         $this->assertEquals(['initial-error', ReCaptcha::E_SCORE_THRESHOLD_NOT_MET], $response->getErrorCodes());
     }

--- a/tests/ReCaptcha/RequestMethod/CurlPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/CurlPostTest.php
@@ -56,6 +56,8 @@ class CurlPostGlobalState
     public static ?array $setoptArrayOptions = null;
 
     public static bool|string $execResponse = 'RESPONSEBODY';
+
+    public static bool $closeCalled = false;
 }
 
 /**
@@ -93,7 +95,7 @@ function curl_exec(\stdClass $ch): bool|string
  */
 function curl_close(\stdClass $ch): void
 {
-    // no-op mock
+    CurlPostGlobalState::$closeCalled = true;
 }
 
 /**
@@ -108,6 +110,7 @@ class CurlPostTest extends TestCase
         CurlPostGlobalState::$initUrl = null;
         CurlPostGlobalState::$setoptArrayOptions = null;
         CurlPostGlobalState::$execResponse = 'RESPONSEBODY';
+        CurlPostGlobalState::$closeCalled = false;
     }
 
     public function testSubmit(): void
@@ -169,5 +172,13 @@ class CurlPostTest extends TestCase
         $response = $pc->submit(new RequestParameters('secret', 'response'));
 
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
+    }
+
+    public function testCurlWrapperCloseDelegatesToNativeFunction(): void
+    {
+        $curl = new Curl();
+        $curl->close(new \stdClass());
+
+        $this->assertTrue(CurlPostGlobalState::$closeCalled);
     }
 }

--- a/tests/ReCaptcha/RequestMethod/CurlPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/CurlPostTest.php
@@ -143,6 +143,25 @@ class CurlPostTest extends TestCase
         $this->assertEquals('RESPONSEBODY', $response);
     }
 
+    public function testLegacyNamedArgumentsCanInjectCurlWrapper(): void
+    {
+        $url = 'OVERRIDE';
+        $pc = new CurlPost(curl: new Curl(), siteVerifyUrl: $url);
+        $response = $pc->submit(new RequestParameters('secret', 'response'));
+
+        $this->assertEquals($url, CurlPostGlobalState::$initUrl);
+        $this->assertEquals('RESPONSEBODY', $response);
+    }
+
+    public function testCurlWrapperMethodsRemainUntyped(): void
+    {
+        $setoptArray = new \ReflectionMethod(Curl::class, 'setoptArray');
+        $close = new \ReflectionMethod(Curl::class, 'close');
+
+        $this->assertFalse($setoptArray->hasReturnType());
+        $this->assertFalse($close->hasReturnType());
+    }
+
     public function testConnectionFailureReturnsError(): void
     {
         CurlPostGlobalState::$execResponse = false;

--- a/tests/ReCaptcha/RequestMethod/CurlPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/CurlPostTest.php
@@ -173,12 +173,4 @@ class CurlPostTest extends TestCase
 
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
     }
-
-    public function testCurlWrapperCloseDelegatesToNativeFunction(): void
-    {
-        $curl = new Curl();
-        $curl->close(new \stdClass());
-
-        $this->assertTrue(CurlPostGlobalState::$closeCalled);
-    }
 }

--- a/tests/ReCaptcha/RequestMethod/CurlPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/CurlPostTest.php
@@ -133,6 +133,16 @@ class CurlPostTest extends TestCase
         $this->assertEquals('RESPONSEBODY', $response);
     }
 
+    public function testLegacyConstructorOverrideSiteVerifyUrl(): void
+    {
+        $url = 'OVERRIDE';
+        $pc = new CurlPost(null, $url);
+        $response = $pc->submit(new RequestParameters('secret', 'response'));
+
+        $this->assertEquals($url, CurlPostGlobalState::$initUrl);
+        $this->assertEquals('RESPONSEBODY', $response);
+    }
+
     public function testConnectionFailureReturnsError(): void
     {
         CurlPostGlobalState::$execResponse = false;

--- a/tests/ReCaptcha/RequestMethod/CurlPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/CurlPostTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -44,61 +42,6 @@ use ReCaptcha\ReCaptcha;
 use ReCaptcha\RequestParameters;
 
 /**
- * Global state for mocking curl functions.
- */
-class CurlPostGlobalState
-{
-    public static ?string $initUrl = null;
-
-    /**
-     * @var null|array<int, mixed>
-     */
-    public static ?array $setoptArrayOptions = null;
-
-    public static bool|string $execResponse = 'RESPONSEBODY';
-
-    public static bool $closeCalled = false;
-}
-
-/**
- * Mock curl_init in the ReCaptcha\RequestMethod namespace.
- */
-function curl_init(?string $url = null): \stdClass
-{
-    CurlPostGlobalState::$initUrl = $url;
-
-    return new \stdClass();
-}
-
-/**
- * Mock curl_setopt_array in the ReCaptcha\RequestMethod namespace.
- *
- * @param array<int, mixed> $options
- */
-function curl_setopt_array(\stdClass $ch, array $options): bool
-{
-    CurlPostGlobalState::$setoptArrayOptions = $options;
-
-    return true;
-}
-
-/**
- * Mock curl_exec in the ReCaptcha\RequestMethod namespace.
- */
-function curl_exec(\stdClass $ch): bool|string
-{
-    return CurlPostGlobalState::$execResponse;
-}
-
-/**
- * Mock curl_close in the ReCaptcha\RequestMethod namespace.
- */
-function curl_close(\stdClass $ch): void
-{
-    CurlPostGlobalState::$closeCalled = true;
-}
-
-/**
  * @internal
  *
  * @coversNothing
@@ -107,70 +50,85 @@ class CurlPostTest extends TestCase
 {
     protected function setUp(): void
     {
-        CurlPostGlobalState::$initUrl = null;
-        CurlPostGlobalState::$setoptArrayOptions = null;
-        CurlPostGlobalState::$execResponse = 'RESPONSEBODY';
-        CurlPostGlobalState::$closeCalled = false;
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped(
+                'The cURL extension is not available.'
+            );
+        }
     }
 
     public function testSubmit(): void
     {
-        $pc = new CurlPost();
+        $curl = $this->getMockBuilder(Curl::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $curl->expects($this->once())
+            ->method('init')
+            ->willReturn(new \stdClass())
+        ;
+        $curl->expects($this->once())
+            ->method('setoptArray')
+            ->willReturn(true)
+        ;
+        $curl->expects($this->once())
+            ->method('exec')
+            ->willReturn('RESPONSEBODY')
+        ;
+
+        $pc = new CurlPost($curl);
         $response = $pc->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals(ReCaptcha::SITE_VERIFY_URL, CurlPostGlobalState::$initUrl);
-
-        /** @var array<int, mixed> $options */
-        $options = CurlPostGlobalState::$setoptArrayOptions;
-        $this->assertTrue($options[CURLOPT_POST]);
         $this->assertEquals('RESPONSEBODY', $response);
     }
 
     public function testOverrideSiteVerifyUrl(): void
     {
         $url = 'OVERRIDE';
-        $pc = new CurlPost($url);
+
+        $curl = $this->getMockBuilder(Curl::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $curl->expects($this->once())
+            ->method('init')
+            ->with($url)
+            ->willReturn(new \stdClass())
+        ;
+        $curl->expects($this->once())
+            ->method('setoptArray')
+            ->willReturn(true)
+        ;
+        $curl->expects($this->once())
+            ->method('exec')
+            ->willReturn('RESPONSEBODY')
+        ;
+
+        $pc = new CurlPost($curl, $url);
         $response = $pc->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals($url, CurlPostGlobalState::$initUrl);
         $this->assertEquals('RESPONSEBODY', $response);
-    }
-
-    public function testLegacyConstructorOverrideSiteVerifyUrl(): void
-    {
-        $url = 'OVERRIDE';
-        $pc = new CurlPost(null, $url);
-        $response = $pc->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals($url, CurlPostGlobalState::$initUrl);
-        $this->assertEquals('RESPONSEBODY', $response);
-    }
-
-    public function testLegacyNamedArgumentsCanInjectCurlWrapper(): void
-    {
-        $url = 'OVERRIDE';
-        $pc = new CurlPost(curl: new Curl(), siteVerifyUrl: $url);
-        $response = $pc->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals($url, CurlPostGlobalState::$initUrl);
-        $this->assertEquals('RESPONSEBODY', $response);
-    }
-
-    public function testCurlWrapperMethodsRemainUntyped(): void
-    {
-        $setoptArray = new \ReflectionMethod(Curl::class, 'setoptArray');
-        $close = new \ReflectionMethod(Curl::class, 'close');
-
-        $this->assertFalse($setoptArray->hasReturnType());
-        $this->assertFalse($close->hasReturnType());
     }
 
     public function testConnectionFailureReturnsError(): void
     {
-        CurlPostGlobalState::$execResponse = false;
-        $pc = new CurlPost();
-        $response = $pc->submit(new RequestParameters('secret', 'response'));
+        $curl = $this->getMockBuilder(Curl::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $curl->expects($this->once())
+            ->method('init')
+            ->willReturn(new \stdClass())
+        ;
+        $curl->expects($this->once())
+            ->method('setoptArray')
+            ->willReturn(true)
+        ;
+        $curl->expects($this->once())
+            ->method('exec')
+            ->willReturn(false)
+        ;
 
+        $pc = new CurlPost($curl);
+        $response = $pc->submit(new RequestParameters('secret', 'response'));
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
     }
 }

--- a/tests/ReCaptcha/RequestMethod/CurlPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/CurlPostTest.php
@@ -108,6 +108,40 @@ class CurlPostTest extends TestCase
         $this->assertEquals('RESPONSEBODY', $response);
     }
 
+    public function testSubmitSetsTimeoutAndPeerVerification(): void
+    {
+        $options = [];
+
+        $curl = $this->getMockBuilder(Curl::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $curl->expects($this->once())
+            ->method('init')
+            ->willReturn(new \stdClass())
+        ;
+        $curl->expects($this->once())
+            ->method('setoptArray')
+            ->willReturnCallback(function ($ch, array $setOptions) use (&$options) {
+                $options = $setOptions;
+
+                return true;
+            })
+        ;
+        $curl->expects($this->once())
+            ->method('exec')
+            ->willReturn('RESPONSEBODY')
+        ;
+
+        $pc = new CurlPost($curl);
+        $pc->submit(new RequestParameters('secret', 'response'));
+
+        $this->assertArrayHasKey(CURLOPT_TIMEOUT, $options);
+        $this->assertEquals(60, $options[CURLOPT_TIMEOUT]);
+        $this->assertArrayHasKey(CURLOPT_SSL_VERIFYPEER, $options);
+        $this->assertTrue($options[CURLOPT_SSL_VERIFYPEER]);
+    }
+
     public function testConnectionFailureReturnsError(): void
     {
         $curl = $this->getMockBuilder(Curl::class)

--- a/tests/ReCaptcha/RequestMethod/PostTest.php
+++ b/tests/ReCaptcha/RequestMethod/PostTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -54,8 +52,16 @@ class PostTest extends TestCase
      * @var null|callable
      */
     public static $assert;
-    protected RequestParameters $parameters;
-    protected int $runcount = 0;
+
+    /**
+     * @var RequestParameters
+     */
+    protected $parameters;
+
+    /**
+     * @var int
+     */
+    protected $runcount = 0;
 
     public function setUp(): void
     {
@@ -71,6 +77,14 @@ class PostTest extends TestCase
     {
         $req = new Post();
         self::$assert = [$this, 'httpContextOptionsCallback'];
+        $req->submit($this->parameters);
+        $this->assertEquals(1, $this->runcount, 'The assertion was ran');
+    }
+
+    public function testSSLContextOptions(): void
+    {
+        $req = new Post();
+        self::$assert = [$this, 'sslContextOptionsCallback'];
         $req->submit($this->parameters);
         $this->assertEquals(1, $this->runcount, 'The assertion was ran');
     }
@@ -97,101 +111,90 @@ class PostTest extends TestCase
     }
 
     /**
-     * @param array<int, mixed> $args
+     * @param array{0: string, 1: bool, 2: resource} $args
      */
-    public function overrideUrlOptions(array $args): void
+    public function overrideUrlOptions(array $args): bool
     {
         ++$this->runcount;
         $this->assertEquals('https://over.ride/some/path', $args[0]);
+
+        return false;
     }
 
     /**
-     * @param array<int, mixed> $args
+     * @param array{0: string, 1: bool, 2: resource} $args
      */
-    public function httpContextOptionsCallback(array $args): void
+    public function httpContextOptionsCallback(array $args): bool
     {
         ++$this->runcount;
         $this->assertCommonOptions($args);
 
-        /** @var resource $context */
-        $context = $args[2];
-        $options = stream_context_get_options($context);
+        /** @var array<string, array<string, mixed>> $options */
+        $options = stream_context_get_options($args[2]);
         $this->assertArrayHasKey('http', $options);
-        $this->assertArrayHasKey('ssl', $options);
 
-        /** @var array<string, mixed> $httpOptions */
-        $httpOptions = $options['http'];
+        $this->assertArrayHasKey('method', $options['http']);
+        $this->assertEquals('POST', $options['http']['method']);
 
-        /** @var array<string, mixed> $sslOptions */
-        $sslOptions = $options['ssl'];
+        $this->assertArrayHasKey('content', $options['http']);
+        $this->assertEquals($this->parameters->toQueryString(), $options['http']['content']);
 
-        $this->assertArrayHasKey('method', $httpOptions);
-        $this->assertEquals('POST', $httpOptions['method']);
+        $this->assertArrayHasKey('header', $options['http']);
+        $this->assertIsString($options['http']['header']);
+        $this->assertStringContainsStringIgnoringCase('Content-type: application/x-www-form-urlencoded', (string) $options['http']['header']);
 
-        $this->assertArrayHasKey('content', $httpOptions);
-        $this->assertEquals($this->parameters->toQueryString(), $httpOptions['content']);
+        $this->assertArrayHasKey('timeout', $options['http']);
+        $this->assertEquals(60, $options['http']['timeout']);
 
-        $this->assertArrayHasKey('header', $httpOptions);
-
-        /** @var string $header */
-        $header = $httpOptions['header'];
-        $this->assertStringContainsStringIgnoringCase('Content-type: application/x-www-form-urlencoded', $header);
-
-        $this->assertArrayHasKey('timeout', $httpOptions);
-        $this->assertEquals(60, $httpOptions['timeout']);
-
-        $this->assertArrayHasKey('verify_peer', $sslOptions);
-        $this->assertTrue((bool) $sslOptions['verify_peer']);
-        $this->assertArrayHasKey('verify_peer_name', $sslOptions);
-        $this->assertTrue((bool) $sslOptions['verify_peer_name']);
+        return false;
     }
 
     /**
-     * @param array<int, mixed> $args
+     * @param array{0: string, 1: bool, 2: resource} $args
+     */
+    public function sslContextOptionsCallback(array $args): bool
+    {
+        ++$this->runcount;
+        $this->assertCommonOptions($args);
+
+        /** @var array<string, array<string, mixed>> $options */
+        $options = stream_context_get_options($args[2]);
+        $this->assertArrayHasKey('ssl', $options);
+        $this->assertArrayHasKey('verify_peer', $options['ssl']);
+        $this->assertTrue($options['ssl']['verify_peer']);
+        $this->assertArrayHasKey('verify_peer_name', $options['ssl']);
+        $this->assertTrue($options['ssl']['verify_peer_name']);
+
+        return false;
+    }
+
+    /**
+     * @param array{0: string, 1: bool, 2: resource} $args
      */
     protected function assertCommonOptions(array $args): void
     {
         $this->assertCount(3, $args);
-
-        /** @var string $url */
-        $url = $args[0];
-        $this->assertStringStartsWith('https://www.google.com/', $url);
+        $this->assertStringStartsWith('https://www.google.com/', $args[0]);
         $this->assertFalse($args[1]);
         $this->assertTrue(is_resource($args[2]), 'The context options should be a resource');
     }
 }
 
-function file_get_contents(string $filename, bool $use_include_path = false, mixed $context = null, int $offset = 0, ?int $length = null): false|string
+/**
+ * @param mixed ...$args
+ *
+ * @return false|string
+ */
+function file_get_contents(...$args)
 {
-    $args = func_get_args();
     if (PostTest::$assert) {
-        /** @var callable $assert */
-        $assert = PostTest::$assert;
-        $result = call_user_func($assert, $args);
-        if (null === $result) {
-            return '';
-        }
+        $result = call_user_func(PostTest::$assert, $args);
 
-        if (is_string($result)) {
-            return $result;
-        }
-
-        if (false === $result) {
-            return $result;
-        }
-
-        return false;
+        return is_string($result) ? $result : false;
     }
 
     // Since we can't represent maxlen in userland...
-    $result = call_user_func_array('\file_get_contents', $args);
-    if (is_string($result)) {
-        return $result;
-    }
+    $result = call_user_func_array('file_get_contents', $args);
 
-    if (false === $result) {
-        return $result;
-    }
-
-    return false;
+    return is_string($result) ? $result : false;
 }

--- a/tests/ReCaptcha/RequestMethod/SocketPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/SocketPostTest.php
@@ -182,6 +182,25 @@ class SocketPostTest extends TestCase
         $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
     }
 
+    public function testLegacyConstructorOverrideSiteVerifyUrl(): void
+    {
+        SocketPostGlobalState::$fgetsResponses = [
+            "HTTP/1.0 200 OK\r\n",
+            "Content-Type: application/json\r\n",
+            "\r\n",
+            'RESPONSEBODY',
+        ];
+
+        $url = 'https://custom.recaptcha.net/recaptcha/api/siteverify';
+        $sp = new SocketPost(null, $url);
+        $response = $sp->submit(new RequestParameters('secret', 'response'));
+
+        $this->assertEquals('ssl://custom.recaptcha.net', SocketPostGlobalState::$fsockopenHostname);
+        $this->assertStringContainsString('POST /recaptcha/api/siteverify HTTP/1.0', SocketPostGlobalState::$fwriteData);
+        $this->assertEquals('RESPONSEBODY', $response);
+        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
+    }
+
     public function testSubmitReturnsResponseWhenHttp11(): void
     {
         SocketPostGlobalState::$fgetsResponses = [
@@ -205,6 +224,7 @@ class SocketPostTest extends TestCase
         $response = $sp->submit(new RequestParameters('secret', 'response'));
 
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
+        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
     }
 
     public function testConnectionFailureWithValidHandleReturnsError(): void
@@ -216,6 +236,7 @@ class SocketPostTest extends TestCase
         $response = $sp->submit(new RequestParameters('secret', 'response'));
 
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
+        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
     }
 
     public function testUrlFailureReturnsError(): void

--- a/tests/ReCaptcha/RequestMethod/SocketPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/SocketPostTest.php
@@ -201,6 +201,33 @@ class SocketPostTest extends TestCase
         $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
     }
 
+    public function testLegacyNamedArgumentsCanInjectSocketWrapper(): void
+    {
+        SocketPostGlobalState::$fgetsResponses = [
+            "HTTP/1.0 200 OK\r\n",
+            "Content-Type: application/json\r\n",
+            "\r\n",
+            'RESPONSEBODY',
+        ];
+
+        $url = 'https://custom.recaptcha.net/recaptcha/api/siteverify';
+        $sp = new SocketPost(socket: new Socket(), siteVerifyUrl: $url);
+        $response = $sp->submit(new RequestParameters('secret', 'response'));
+
+        $this->assertEquals('ssl://custom.recaptcha.net', SocketPostGlobalState::$fsockopenHostname);
+        $this->assertStringContainsString('POST /recaptcha/api/siteverify HTTP/1.0', SocketPostGlobalState::$fwriteData);
+        $this->assertEquals('RESPONSEBODY', $response);
+        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
+    }
+
+    public function testSocketWrapperKeepsLegacyMethods(): void
+    {
+        $class = new \ReflectionClass(Socket::class);
+
+        $this->assertTrue($class->hasMethod('fgets'));
+        $this->assertTrue($class->hasMethod('feof'));
+    }
+
     public function testSubmitReturnsResponseWhenHttp11(): void
     {
         SocketPostGlobalState::$fgetsResponses = [

--- a/tests/ReCaptcha/RequestMethod/SocketPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/SocketPostTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -44,325 +42,107 @@ use ReCaptcha\ReCaptcha;
 use ReCaptcha\RequestParameters;
 
 /**
- * Global state for mocking socket functions.
- */
-class SocketPostGlobalState
-{
-    public static ?string $fsockopenHostname = null;
-    public static int $fsockopenErrno = 0;
-    public static string $fsockopenErrstr = '';
-    public static bool $fsockopenSuccess = true;
-    public static string $fwriteData = '';
-
-    /**
-     * @var array<int, false|string>
-     */
-    public static array $fgetsResponses = [];
-    public static int $feofCount = 0;
-    public static bool $fcloseCalled = false;
-    public static bool $streamSetTimeoutSuccess = true;
-}
-
-/**
- * Mock fsockopen in the ReCaptcha\RequestMethod namespace.
- */
-function fsockopen(string $hostname, int $port = -1, int &$errno = 0, string &$errstr = '', ?float $timeout = null): false|\stdClass
-{
-    SocketPostGlobalState::$fsockopenHostname = $hostname;
-    $errno = SocketPostGlobalState::$fsockopenErrno;
-    $errstr = SocketPostGlobalState::$fsockopenErrstr;
-
-    return SocketPostGlobalState::$fsockopenSuccess ? new \stdClass() : false;
-}
-
-/**
- * Mock fwrite in the ReCaptcha\RequestMethod namespace.
- */
-function fwrite(\stdClass $handle, string $string, ?int $length = null): int
-{
-    SocketPostGlobalState::$fwriteData .= $string;
-
-    return strlen($string);
-}
-
-/**
- * Mock stream_get_contents in the ReCaptcha\RequestMethod namespace.
- */
-function stream_get_contents(\stdClass $handle, ?int $length = null, int $offset = -1): false|string
-{
-    if (empty(SocketPostGlobalState::$fgetsResponses)) {
-        return false;
-    }
-
-    $result = '';
-    foreach (SocketPostGlobalState::$fgetsResponses as $response) {
-        if (false !== $response) {
-            $result .= $response;
-        }
-    }
-    SocketPostGlobalState::$fgetsResponses = [];
-
-    return $result;
-}
-
-/**
- * Mock stream_set_timeout in the ReCaptcha\RequestMethod namespace.
- */
-function stream_set_timeout(\stdClass $handle, int $seconds, int $microseconds = 0): bool
-{
-    return SocketPostGlobalState::$streamSetTimeoutSuccess;
-}
-
-/**
- * Mock fclose in the ReCaptcha\RequestMethod namespace.
- */
-function fclose(\stdClass $handle): bool
-{
-    SocketPostGlobalState::$fcloseCalled = true;
-
-    return true;
-}
-
-/**
  * @internal
  *
  * @coversNothing
  */
 class SocketPostTest extends TestCase
 {
-    protected function setUp(): void
+    public function testSubmitSuccess(): void
     {
-        SocketPostGlobalState::$fsockopenHostname = null;
-        SocketPostGlobalState::$fsockopenErrno = 0;
-        SocketPostGlobalState::$fsockopenErrstr = '';
-        SocketPostGlobalState::$fsockopenSuccess = true;
-        SocketPostGlobalState::$fwriteData = '';
-        SocketPostGlobalState::$fgetsResponses = [];
-        SocketPostGlobalState::$fcloseCalled = false;
-        SocketPostGlobalState::$streamSetTimeoutSuccess = true;
-    }
+        $socket = $this->createMock(Socket::class);
+        $socket->expects($this->once())
+            ->method('fsockopen')
+            ->willReturn(true)
+        ;
+        $socket->expects($this->once())
+            ->method('fwrite')
+        ;
+        $socket->expects($this->once())
+            ->method('fgets')
+            ->willReturn("HTTP/1.0 200 OK\n\nRESPONSEBODY")
+        ;
+        $socket->expects($this->exactly(2))
+            ->method('feof')
+            ->willReturnOnConsecutiveCalls(false, true)
+        ;
+        $socket->expects($this->once())
+            ->method('fclose')
+            ->willReturn(true)
+        ;
 
-    public function testSubmit(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('ssl://www.google.com', SocketPostGlobalState::$fsockopenHostname);
-        $this->assertStringContainsString('secret=secret', SocketPostGlobalState::$fwriteData);
-        $this->assertStringContainsString('response=response', SocketPostGlobalState::$fwriteData);
+        $ps = new SocketPost($socket);
+        $response = $ps->submit(new RequestParameters('secret', 'response', 'remoteip', 'version'));
         $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
     }
 
     public function testOverrideSiteVerifyUrl(): void
     {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
+        $socket = $this->createMock(Socket::class);
+        $socket->expects($this->once())
+            ->method('fsockopen')
+            ->with('ssl://over.ride', 443, 0, '', 30)
+            ->willReturn(true)
+        ;
+        $socket->expects($this->once())
+            ->method('fwrite')
+            ->with($this->matchesRegularExpression('/^POST \/some\/path.*Host: over\.ride/s'))
+        ;
+        $socket->expects($this->once())
+            ->method('fgets')
+            ->willReturn("HTTP/1.0 200 OK\n\nRESPONSEBODY")
+        ;
+        $socket->expects($this->exactly(2))
+            ->method('feof')
+            ->willReturnOnConsecutiveCalls(false, true)
+        ;
+        $socket->expects($this->once())
+            ->method('fclose')
+            ->willReturn(true)
+        ;
 
-        $url = 'https://custom.recaptcha.net/recaptcha/api/siteverify';
-        $sp = new SocketPost($url);
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('ssl://custom.recaptcha.net', SocketPostGlobalState::$fsockopenHostname);
-        $this->assertStringContainsString('POST /recaptcha/api/siteverify HTTP/1.0', SocketPostGlobalState::$fwriteData);
-        $this->assertStringContainsString('secret=secret', SocketPostGlobalState::$fwriteData);
-        $this->assertStringContainsString('response=response', SocketPostGlobalState::$fwriteData);
+        $ps = new SocketPost($socket, 'https://over.ride/some/path');
+        $response = $ps->submit(new RequestParameters('secret', 'response', 'remoteip', 'version'));
         $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
     }
 
-    public function testLegacyConstructorOverrideSiteVerifyUrl(): void
+    public function testSubmitBadResponse(): void
     {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
+        $socket = $this->createMock(Socket::class);
+        $socket->expects($this->once())
+            ->method('fsockopen')
+            ->willReturn(true)
+        ;
+        $socket->expects($this->once())
+            ->method('fwrite')
+        ;
+        $socket->expects($this->once())
+            ->method('fgets')
+            ->willReturn('HTTP/1.0 500 NOPEn\nBOBBINS')
+        ;
+        $socket->expects($this->exactly(2))
+            ->method('feof')
+            ->willReturnOnConsecutiveCalls(false, true)
+        ;
+        $socket->expects($this->once())
+            ->method('fclose')
+            ->willReturn(true)
+        ;
 
-        $url = 'https://custom.recaptcha.net/recaptcha/api/siteverify';
-        $sp = new SocketPost(null, $url);
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('ssl://custom.recaptcha.net', SocketPostGlobalState::$fsockopenHostname);
-        $this->assertStringContainsString('POST /recaptcha/api/siteverify HTTP/1.0', SocketPostGlobalState::$fwriteData);
-        $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
-    }
-
-    public function testLegacyNamedArgumentsCanInjectSocketWrapper(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
-
-        $url = 'https://custom.recaptcha.net/recaptcha/api/siteverify';
-        $sp = new SocketPost(socket: new Socket(), siteVerifyUrl: $url);
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('ssl://custom.recaptcha.net', SocketPostGlobalState::$fsockopenHostname);
-        $this->assertStringContainsString('POST /recaptcha/api/siteverify HTTP/1.0', SocketPostGlobalState::$fwriteData);
-        $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
-    }
-
-    public function testSocketWrapperKeepsLegacyMethods(): void
-    {
-        $class = new \ReflectionClass(Socket::class);
-
-        $this->assertTrue($class->hasMethod('fgets'));
-        $this->assertTrue($class->hasMethod('feof'));
-    }
-
-    public function testSubmitReturnsResponseWhenHttp11(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.1 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
-    }
-
-    public function testStreamTimeoutFailureReturnsError(): void
-    {
-        SocketPostGlobalState::$streamSetTimeoutSuccess = false;
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
-    }
-
-    public function testConnectionFailureWithValidHandleReturnsError(): void
-    {
-        SocketPostGlobalState::$fsockopenSuccess = true;
-        SocketPostGlobalState::$fsockopenErrno = 1;
-        SocketPostGlobalState::$fsockopenErrstr = 'Connection refused';
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
-    }
-
-    public function testUrlFailureReturnsError(): void
-    {
-        $sp = new SocketPost('invalid_url');
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
-    }
-
-    public function testSubmitWithFgetsFailure(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            false,
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
-    }
-
-    public function testMalformedResponseReturnsError(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
+        $ps = new SocketPost($socket);
+        $response = $ps->submit(new RequestParameters('secret', 'response', 'remoteip', 'version'));
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
     }
 
     public function testConnectionFailureReturnsError(): void
     {
-        SocketPostGlobalState::$fsockopenSuccess = false;
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
+        $socket = $this->createMock(Socket::class);
+        $socket->expects($this->once())
+            ->method('fsockopen')
+            ->willReturn(false)
+        ;
+        $ps = new SocketPost($socket);
+        $response = $ps->submit(new RequestParameters('secret', 'response', 'remoteip', 'version'));
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
-    }
-
-    public function testBadResponseReturnsError(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 500 Internal Server Error\r\n",
-            "\r\n",
-            'FAIL',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
-    }
-
-    public function testStreamGetContentsReturnsFalse(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
-    }
-
-    public function testBadResponseReturnsErrorWhenHttp11(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.1 500 Internal Server Error\r\n",
-            "\r\n",
-            'FAIL',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
-    }
-
-    public function testBadResponseReturnsErrorWhenHttp2(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/2.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
     }
 }

--- a/tests/ReCaptcha/RequestParametersTest.php
+++ b/tests/ReCaptcha/RequestParametersTest.php
@@ -87,4 +87,11 @@ class RequestParametersTest extends TestCase
             ],
         ];
     }
+
+    public function testClassRemainsExtendable(): void
+    {
+        $class = new \ReflectionClass(RequestParameters::class);
+
+        $this->assertFalse($class->isReadOnly());
+    }
 }

--- a/tests/ReCaptcha/RequestParametersTest.php
+++ b/tests/ReCaptcha/RequestParametersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -75,23 +73,12 @@ class RequestParametersTest extends TestCase
     public static function provideValidData(): array
     {
         return [
-            [
-                'SECRET', 'RESPONSE', 'REMOTEIP', 'VERSION',
+            ['SECRET', 'RESPONSE', 'REMOTEIP', 'VERSION',
                 ['secret' => 'SECRET', 'response' => 'RESPONSE', 'remoteip' => 'REMOTEIP', 'version' => 'VERSION'],
-                'secret=SECRET&response=RESPONSE&remoteip=REMOTEIP&version=VERSION',
-            ],
-            [
-                'SECRET', 'RESPONSE', null, null,
+                'secret=SECRET&response=RESPONSE&remoteip=REMOTEIP&version=VERSION'],
+            ['SECRET', 'RESPONSE', null, null,
                 ['secret' => 'SECRET', 'response' => 'RESPONSE'],
-                'secret=SECRET&response=RESPONSE',
-            ],
+                'secret=SECRET&response=RESPONSE'],
         ];
-    }
-
-    public function testClassRemainsExtendable(): void
-    {
-        $class = new \ReflectionClass(RequestParameters::class);
-
-        $this->assertFalse($class->isReadOnly());
     }
 }

--- a/tests/ReCaptcha/ResponseTest.php
+++ b/tests/ReCaptcha/ResponseTest.php
@@ -126,6 +126,21 @@ class ResponseTest extends TestCase
         ];
     }
 
+    public function testFromJsonReturnsInvalidJsonForNull(): void
+    {
+        $response = Response::fromJson(null);
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals([ReCaptcha::E_INVALID_JSON], $response->getErrorCodes());
+    }
+
+    public function testClassRemainsExtendable(): void
+    {
+        $class = new \ReflectionClass(Response::class);
+
+        $this->assertFalse($class->isReadOnly());
+    }
+
     public function testIsSuccess(): void
     {
         $response = new Response(true);

--- a/tests/ReCaptcha/ResponseTest.php
+++ b/tests/ReCaptcha/ResponseTest.php
@@ -100,8 +100,20 @@ class ResponseTest extends TestCase
                 true, [], 'google.com', null, null, null, null,
             ],
             [
+                '{"success": "true"}',
+                true, [], null, null, null, null, null,
+            ],
+            [
+                '{"success": 1}',
+                true, [], null, null, null, null, null,
+            ],
+            [
                 '{"success": false}',
                 false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
+            ],
+            [
+                '{}',
+                false, [ReCaptcha::E_INVALID_JSON], null, null, null, null, null,
             ],
             [
                 '{"success": false, "hostname": "google.com"}',

--- a/tests/ReCaptcha/ResponseTest.php
+++ b/tests/ReCaptcha/ResponseTest.php
@@ -53,7 +53,7 @@ class ResponseTest extends TestCase
      * @param array<string> $errorCodes
      */
     #[DataProvider('provideJson')]
-    public function testFromJson(string $json, bool $success, array $errorCodes, ?string $hostname, ?string $challengeTs, ?string $apkPackageName, ?float $score, ?string $action): void
+    public function testFromJson(mixed $json, bool $success, array $errorCodes, ?string $hostname, ?string $challengeTs, ?string $apkPackageName, ?float $score, ?string $action): void
     {
         $response = Response::fromJson($json);
         $this->assertEquals($success, $response->isSuccess());
@@ -66,7 +66,7 @@ class ResponseTest extends TestCase
     }
 
     /**
-     * @return array<int, array{0: string, 1: bool, 2: array<string>, 3: null|string, 4: null|string, 5: null|string, 6: null|float, 7: null|string}>
+     * @return array<int, array{0: mixed, 1: bool, 2: array<string>, 3: null|string, 4: null|string, 5: null|string, 6: null|float, 7: null|string}>
      */
     public static function provideJson(): array
     {
@@ -124,6 +124,10 @@ class ResponseTest extends TestCase
                 false, [ReCaptcha::E_INVALID_JSON], null, null, null, null, null,
             ],
             [
+                null,
+                false, [ReCaptcha::E_INVALID_JSON], null, null, null, null, null,
+            ],
+            [
                 '{"success": false, "error-codes": "invalid-input-secret"}',
                 false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
             ],
@@ -136,14 +140,6 @@ class ResponseTest extends TestCase
                 false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
             ],
         ];
-    }
-
-    public function testFromJsonReturnsInvalidJsonForNull(): void
-    {
-        $response = Response::fromJson(null);
-
-        $this->assertFalse($response->isSuccess());
-        $this->assertEquals([ReCaptcha::E_INVALID_JSON], $response->getErrorCodes());
     }
 
     public function testClassRemainsExtendable(): void

--- a/tests/ReCaptcha/ResponseTest.php
+++ b/tests/ReCaptcha/ResponseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -50,23 +48,23 @@ use PHPUnit\Framework\TestCase;
 class ResponseTest extends TestCase
 {
     /**
-     * @param array<string> $errorCodes
+     * @param array<int, string> $errorCodes
      */
     #[DataProvider('provideJson')]
-    public function testFromJson(mixed $json, bool $success, array $errorCodes, ?string $hostname, ?string $challengeTs, ?string $apkPackageName, ?float $score, ?string $action): void
+    public function testFromJson(string $json, bool $success, array $errorCodes, ?string $hostname, ?string $challengeTs, ?string $apkPackageName, ?float $score, ?string $action): void
     {
         $response = Response::fromJson($json);
         $this->assertEquals($success, $response->isSuccess());
         $this->assertEquals($errorCodes, $response->getErrorCodes());
-        $this->assertEquals($hostname ?? '', $response->getHostname());
-        $this->assertEquals($challengeTs ?? '', $response->getChallengeTs());
-        $this->assertEquals($apkPackageName ?? '', $response->getApkPackageName());
+        $this->assertEquals($hostname, $response->getHostname());
+        $this->assertEquals($challengeTs, $response->getChallengeTs());
+        $this->assertEquals($apkPackageName, $response->getApkPackageName());
         $this->assertEquals($score, $response->getScore());
-        $this->assertEquals($action ?? '', $response->getAction());
+        $this->assertEquals($action, $response->getAction());
     }
 
     /**
-     * @return array<int, array{0: mixed, 1: bool, 2: array<string>, 3: null|string, 4: null|string, 5: null|string, 6: null|float, 7: null|string}>
+     * @return array<int, array{0: string, 1: bool, 2: array<int, string>, 3: null|string, 4: null|string, 5: null|string, 6: null|float, 7: null|string}>
      */
     public static function provideJson(): array
     {
@@ -100,20 +98,8 @@ class ResponseTest extends TestCase
                 true, [], 'google.com', null, null, null, null,
             ],
             [
-                '{"success": "true"}',
-                true, [], null, null, null, null, null,
-            ],
-            [
-                '{"success": 1}',
-                true, [], null, null, null, null, null,
-            ],
-            [
                 '{"success": false}',
                 false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
-            ],
-            [
-                '{}',
-                false, [ReCaptcha::E_INVALID_JSON], null, null, null, null, null,
             ],
             [
                 '{"success": false, "hostname": "google.com"}',
@@ -123,30 +109,7 @@ class ResponseTest extends TestCase
                 'BAD JSON',
                 false, [ReCaptcha::E_INVALID_JSON], null, null, null, null, null,
             ],
-            [
-                null,
-                false, [ReCaptcha::E_INVALID_JSON], null, null, null, null, null,
-            ],
-            [
-                '{"success": false, "error-codes": "invalid-input-secret"}',
-                false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
-            ],
-            [
-                '{"success": false, "error-codes": null}',
-                false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
-            ],
-            [
-                '{"success": false, "error-codes": 123}',
-                false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
-            ],
         ];
-    }
-
-    public function testClassRemainsExtendable(): void
-    {
-        $class = new \ReflectionClass(Response::class);
-
-        $this->assertFalse($class->isReadOnly());
     }
 
     public function testIsSuccess(): void
@@ -158,7 +121,7 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->isSuccess());
 
         $response = new Response(true, [], 'example.com');
-        $this->assertEquals('example.com', $response->getHostname());
+        $this->assertEquals('example.com', $response->getHostName());
     }
 
     public function testGetErrorCodes(): void
@@ -179,11 +142,12 @@ class ResponseTest extends TestCase
     public function testGetChallengeTs(): void
     {
         $timestamp = 'timestamp';
+        $errorCodes = [];
         $response = new Response(true, [], 'hostname', $timestamp);
         $this->assertEquals($timestamp, $response->getChallengeTs());
     }
 
-    public function testGetApkPackageName(): void
+    public function TestGetApkPackageName(): void
     {
         $apk = 'apk';
         $response = new Response(true, [], 'hostname', 'timestamp', 'apk');

--- a/tests/ReCaptcha/ResponseTest.php
+++ b/tests/ReCaptcha/ResponseTest.php
@@ -109,6 +109,20 @@ class ResponseTest extends TestCase
                 'BAD JSON',
                 false, [ReCaptcha::E_INVALID_JSON], null, null, null, null, null,
             ],
+            // Only a real boolean true counts as success. A loose comparison
+            // would treat any non-empty string, including "false", as success.
+            [
+                '{"success": "false"}',
+                false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
+            ],
+            [
+                '{"success": "true"}',
+                false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
+            ],
+            [
+                '{"success": 1}',
+                false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
+            ],
         ];
     }
 


### PR DESCRIPTION
**Closes #628**

Thanks again, @acoulton and @mbabker, for raising and detailing the BC concerns.  
This PR focuses on restoring 1.x compatibility expectations while preserving the useful reliability and hardening work already introduced.

## What this PR does

### 1) Restores 1.x public API compatibility
- Removed `readonly` behavior from public non-final DTOs (`Response`, `RequestParameters`) so extension/mocking remains possible.
- Kept `RequestMethod::submit()` without a native return type (1.x-compatible contract).
- Added runtime guard in `ReCaptcha::verify()` to safely handle non-string request-method responses (`E_BAD_RESPONSE`).
- Relaxed public scalar signature strictness where 1.x behavior expected broader input, especially `verify(...)`.
- Restored legacy constructor compatibility for:
  - `new CurlPost(null, $url)`
  - `new SocketPost(null, $url)`
- Preserved source-compatible constructor parameter names for named-argument usage.
- Restored `Curl` and `Socket` wrapper classes as public compatibility surfaces.

### 2) Fixes compatibility/quality edge cases found during review
- Fixed `SocketPost` early-return path to ensure handle close when timeout setup fails.
- Ensured old constructor override behavior does not silently drop custom siteverify URLs.
- Preserved legacy-compatible `Response::fromJson(...)` semantics needed for 1.x consumers.

### 3) Keeps the good hardening/reliability improvements
- cURL handle cleanup remains in place.
- `SocketPost` HTTP/1.1 handling remains in place.
- Explicit nullable property initialization in `ReCaptcha` remains.
- `"0"` response handling remains valid.
- TLS peer verification hardening in fallback request flow remains.
- PHPStan / tooling modernization remains.

## Tests and coverage updates
Added/updated regression tests for:
- custom `RequestMethod` implementation without native return type
- non-string `RequestMethod` response handling
- `verify(null)` compatibility behavior
- `"0"` response handling
- numeric-string score threshold usage
- legacy constructor forms for CurlPost/SocketPost
- extendability of `Response` and `RequestParameters`
- socket timeout failure close path
- wrapper compatibility behavior (`Curl` / `Socket`)

## Documentation updates
- Added/expanded **Public API compatibility** guidance.
- Clarified 1.x public API expectations and major-version-only change types.
- Added a compatibility release notes section for 1.5.1 behavior.

## Validation run
- `vendor/bin/phpunit --no-coverage` 
- `vendor/bin/phpstan` 
- `vendor/bin/php-cs-fixer check --using-cache=no` 

Only caution (not new, but important):

- CurlPost / Post / SocketPost still allow overriding the verify URL for compatibility. That is fine when it’s trusted config, but if any app passes user-controlled input there, it can become SSRF-like behavior.
- Example files intentionally use raw request data for demo purposes; that is expected and not library-core behavior.

---

#### Note to @rowan-m
I already bumped the client version string to `1.5.1` in this work to keep the release path straightforward and avoid extra follow-up edits.  
If that decision should stay maintainer-only, I’m sorry — please feel free to adjust/revert that part as you prefer.

---