### PR TITLE
ci/backward-compatibility-check

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,6 +58,20 @@ jobs:
         COVERALLS_FLAG_NAME: php-${{ matrix.php }}
       run: vendor/bin/php-coveralls -v
 
+  backward-compatibility:
+    name: Backward compatibility check
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # The check compares the PR against the last release tag, so it needs
+        # the full history rather than a shallow clone.
+        fetch-depth: 0
+
+    - name: Check for BC breaks since the last release
+      uses: docker://nyholm/roave-bc-check-ga
+
   finish:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -69,8 +69,23 @@ jobs:
         # the full history rather than a shallow clone.
         fetch-depth: 0
 
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+
+    # Installed into its own directory at run time rather than through a
+    # docker action or this project's dev dependencies, so the check always
+    # runs with current releases and its dependencies stay out of the
+    # library's own dependency resolution.
+    - name: Install roave/backward-compatibility-check
+      run: |
+        mkdir bc-check
+        cd bc-check
+        composer require --no-interaction roave/backward-compatibility-check
+
     - name: Check for BC breaks since the last release
-      uses: docker://nyholm/roave-bc-check-ga
+      run: bc-check/vendor/bin/roave-backward-compatibility-check --format=github-actions
 
   finish:
     needs: build

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,10 +18,10 @@ jobs:
         php: ['8.4', '8.5']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: ${{ matrix.php }}
         extensions: dom, curl, libxml, mbstring, tokenizer, xml, xmlwriter
@@ -32,7 +32,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ matrix.php }}-${{ hashFiles('**/composer.lock') }}
@@ -63,14 +63,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         # The check compares the PR against the last release tag, so it needs
         # the full history rather than a shallow clone.
         fetch-depth: 0
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
       with:
         php-version: '8.4'
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,901 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to function is_string\(\) with non\-falsy\-string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: src/ReCaptcha/ReCaptcha.php
+
+		-
+			message: '#^Parameter \#1 \$string1 of function strcasecmp expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/ReCaptcha/ReCaptcha.php
+
+		-
+			message: '#^Property ReCaptcha\\ReCaptcha\:\:\$action has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/ReCaptcha/ReCaptcha.php
+
+		-
+			message: '#^Property ReCaptcha\\ReCaptcha\:\:\$apkPackageName has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/ReCaptcha/ReCaptcha.php
+
+		-
+			message: '#^Property ReCaptcha\\ReCaptcha\:\:\$hostname has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/ReCaptcha/ReCaptcha.php
+
+		-
+			message: '#^Property ReCaptcha\\ReCaptcha\:\:\$threshold has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/ReCaptcha/ReCaptcha.php
+
+		-
+			message: '#^Property ReCaptcha\\ReCaptcha\:\:\$timeoutSeconds has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/ReCaptcha/ReCaptcha.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\Curl\:\:init\(\) should return resource but returns \(CurlHandle\|false\)\.$#'
+			identifier: return.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Curl.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\Curl\:\:setoptArray\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Curl.php
+
+		-
+			message: '#^Parameter \#1 \$handle of function curl_exec expects CurlHandle, resource given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Curl.php
+
+		-
+			message: '#^Parameter \#1 \$handle of function curl_setopt_array expects CurlHandle, resource given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Curl.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\CurlPost\:\:submit\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/CurlPost.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\Post\:\:submit\(\) should return string but returns mixed\.$#'
+			identifier: return.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Post.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\Socket\:\:fgets\(\) should return string but returns string\|false\.$#'
+			identifier: return.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\Socket\:\:fsockopen\(\) should return resource but returns false\.$#'
+			identifier: return.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fclose expects resource, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function feof expects resource, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fgets expects resource, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Parameter \#1 \$stream of function fwrite expects resource, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Parameter \#2 \$length of function fgets expects int\<0, max\>\|null, int\|null given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Parameter \#3 \$length of function fwrite expects int\<0, max\>\|null, int given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Parameter \#5 \$timeout of function fsockopen expects float\|null, float\|string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Property ReCaptcha\\RequestMethod\\Socket\:\:\$handle has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/ReCaptcha/RequestMethod/Socket.php
+
+		-
+			message: '#^Cannot access offset ''host'' on array\{scheme\?\: string, host\?\: string, port\?\: int\<0, 65535\>, user\?\: string, pass\?\: string, path\?\: string, query\?\: string, fragment\?\: string\}\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 2
+			path: src/ReCaptcha/RequestMethod/SocketPost.php
+
+		-
+			message: '#^Cannot access offset ''path'' on array\{scheme\?\: string, host\?\: string, port\?\: int\<0, 65535\>, user\?\: string, pass\?\: string, path\?\: string, query\?\: string, fragment\?\: string\}\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ReCaptcha/RequestMethod/SocketPost.php
+
+		-
+			message: '#^Cannot access offset 1 on list\<string\>\|false\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ReCaptcha/RequestMethod/SocketPost.php
+
+		-
+			message: '#^Parameter \#1 \$url of function parse_url expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/RequestMethod/SocketPost.php
+
+		-
+			message: '#^Property ReCaptcha\\RequestMethod\\SocketPost\:\:\$siteVerifyUrl has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: src/ReCaptcha/RequestMethod/SocketPost.php
+
+		-
+			message: '#^Strict comparison using \=\=\= between false and resource will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/ReCaptcha/RequestMethod/SocketPost.php
+
+		-
+			message: '#^Call to function is_null\(\) with string will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 2
+			path: src/ReCaptcha/RequestParameters.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParameters\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ReCaptcha/RequestParameters.php
+
+		-
+			message: '#^Property ReCaptcha\\RequestParameters\:\:\$remoteIp \(string\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/ReCaptcha/RequestParameters.php
+
+		-
+			message: '#^Property ReCaptcha\\RequestParameters\:\:\$version \(string\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/ReCaptcha/RequestParameters.php
+
+		-
+			message: '#^Cannot access offset ''action'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Cannot access offset ''apk_package_name'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Cannot access offset ''challenge_ts'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Cannot access offset ''error\-codes'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Cannot access offset ''hostname'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Cannot access offset ''score'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Cannot access offset ''success'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Method ReCaptcha\\Response\:\:__construct\(\) has parameter \$errorCodes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Method ReCaptcha\\Response\:\:getErrorCodes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Method ReCaptcha\\Response\:\:toArray\(\) should return array\{success\: bool, hostname\: string, challenge_ts\: string, apk_package_name\: string, score\: float\|null, action\: string, error\-codes\: array\<string\>\} but returns array\{success\: bool, hostname\: string, challenge_ts\: string, apk_package_name\: string, score\: float, action\: string, error\-codes\: array\}\.$#'
+			identifier: return.type
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Parameter \#1 \$value of function floatval expects array\|bool\|float\|GMP\|int\|resource\|SimpleXMLElement\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Parameter \#3 \$hostname of class ReCaptcha\\Response constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Parameter \#4 \$challengeTs of class ReCaptcha\\Response constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Parameter \#5 \$apkPackageName of class ReCaptcha\\Response constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Parameter \#7 \$action of class ReCaptcha\\Response constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 3
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Property ReCaptcha\\Response\:\:\$errorCodes type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Property ReCaptcha\\Response\:\:\$score \(float\) does not accept float\|null\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/ReCaptcha/Response.php
+
+		-
+			message: '#^Class ReCaptcha\\ReCaptcha referenced with incorrect case\: ReCaptcha\\Recaptcha\.$#'
+			identifier: class.nameCase
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:getMockRequestMethod\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:getMockRequestMethod\(\) has parameter \$responseJson with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:invalidSecretProvider\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testDefaultRequestMethod\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testExceptionThrownOnInvalidSecret\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testExceptionThrownOnInvalidSecret\(\) has parameter \$invalid with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyAboveThreshold\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyActionMatch\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyActionMisMatch\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyApkPackageNameMatch\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyApkPackageNameMisMatch\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyBelowThreshold\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyHostnameMatch\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyHostnameMisMatch\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyMergesErrors\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyOverTimeout\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyReturnsErrorOnMissingResponse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyReturnsInitialResponseWithoutAdditionalChecks\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyReturnsResponse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ReCaptchaTest\:\:testVerifyWithinTimeout\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Parameter \#1 \$secret of class ReCaptcha\\ReCaptcha constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Parameter \#1 \$threshold of method ReCaptcha\\ReCaptcha\:\:setScoreThreshold\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 3
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Parameter \#1 \$timeoutSeconds of method ReCaptcha\\ReCaptcha\:\:setChallengeTimeout\(\) expects int, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Parameter \#2 \$requestMethod of class ReCaptcha\\ReCaptcha constructor expects ReCaptcha\\RequestMethod\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 13
+			path: tests/ReCaptcha/ReCaptchaTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\CurlPostTest\:\:testConnectionFailureReturnsError\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/CurlPostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\CurlPostTest\:\:testOverrideSiteVerifyUrl\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/CurlPostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\CurlPostTest\:\:testSubmit\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/CurlPostTest.php
+
+		-
+			message: '#^Cannot access offset ''content'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Cannot access offset ''header'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Cannot access offset ''method'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Cannot access offset ''verify_peer'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Cannot call method toQueryString\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Cannot use \+\+ on mixed\.$#'
+			identifier: preInc.type
+			count: 3
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Function ReCaptcha\\RequestMethod\\file_get_contents\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:assertCommonOptions\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:assertCommonOptions\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:connectionFailureResponse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:httpContextOptionsCallback\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:httpContextOptionsCallback\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:overrideUrlOptions\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:overrideUrlOptions\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:sslContextOptionsCallback\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:sslContextOptionsCallback\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:testConnectionFailureReturnsError\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:testHTTPContextOptions\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:testOverrideVerifyUrl\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\PostTest\:\:testSSLContextOptions\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Parameter \#1 \$callback of function call_user_func expects callable\(\)\: mixed, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Parameter \#1 \$params of method ReCaptcha\\RequestMethod\\Post\:\:submit\(\) expects ReCaptcha\\RequestParameters, mixed given\.$#'
+			identifier: argument.type
+			count: 4
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Parameter \#1 \$stream_or_context of function stream_context_get_options expects resource, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Parameter \#2 \$array of method PHPUnit\\Framework\\Assert\:\:assertArrayHasKey\(\) expects array\<mixed\>\|ArrayAccess\<\(int\|string\), mixed\>, mixed given\.$#'
+			identifier: argument.type
+			count: 4
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Parameter \#2 \$haystack of method PHPUnit\\Framework\\Assert\:\:assertStringContainsStringIgnoringCase\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Parameter \#2 \$string of method PHPUnit\\Framework\\Assert\:\:assertStringStartsWith\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Property ReCaptcha\\RequestMethod\\PostTest\:\:\$assert has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Property ReCaptcha\\RequestMethod\\PostTest\:\:\$parameters has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Property ReCaptcha\\RequestMethod\\PostTest\:\:\$runcount has no type specified\.$#'
+			identifier: missingType.property
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/PostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\SocketPostTest\:\:testConnectionFailureReturnsError\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/SocketPostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\SocketPostTest\:\:testOverrideSiteVerifyUrl\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/SocketPostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\SocketPostTest\:\:testSubmitBadResponse\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/SocketPostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestMethod\\SocketPostTest\:\:testSubmitSuccess\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestMethod/SocketPostTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:provideValidData\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToArray\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToArray\(\) has parameter \$expectedArray with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToArray\(\) has parameter \$expectedQuery with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToArray\(\) has parameter \$remoteIp with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToArray\(\) has parameter \$response with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToArray\(\) has parameter \$secret with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToArray\(\) has parameter \$version with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToQueryString\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToQueryString\(\) has parameter \$expectedArray with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToQueryString\(\) has parameter \$expectedQuery with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToQueryString\(\) has parameter \$remoteIp with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToQueryString\(\) has parameter \$response with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToQueryString\(\) has parameter \$secret with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\RequestParametersTest\:\:testToQueryString\(\) has parameter \$version with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Parameter \#1 \$secret of class ReCaptcha\\RequestParameters constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Parameter \#2 \$response of class ReCaptcha\\RequestParameters constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Parameter \#3 \$remoteIp of class ReCaptcha\\RequestParameters constructor expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Parameter \#4 \$version of class ReCaptcha\\RequestParameters constructor expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/ReCaptcha/RequestParametersTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:TestGetApkPackageName\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:provideJson\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testFromJson\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testFromJson\(\) has parameter \$action with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testFromJson\(\) has parameter \$apkPackageName with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testFromJson\(\) has parameter \$challengeTs with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testFromJson\(\) has parameter \$errorCodes with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testFromJson\(\) has parameter \$hostname with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testFromJson\(\) has parameter \$json with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testFromJson\(\) has parameter \$score with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testFromJson\(\) has parameter \$success with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testGetAction\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testGetChallengeTs\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testGetErrorCodes\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testGetHostname\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testGetScore\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testIsSuccess\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Method ReCaptcha\\ResponseTest\:\:testToArray\(\) has no return type specified\.$#'
+			identifier: missingType.return
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Parameter \#1 \$json of static method ReCaptcha\\Response\:\:fromJson\(\) expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/ReCaptcha/ResponseTest.php
+
+		-
+			message: '#^Parameter \#6 \$score of class ReCaptcha\\Response constructor expects float\|null, string given\.$#'
+			identifier: argument.type
+			count: 2
+			path: tests/ReCaptcha/ResponseTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     level: max
     paths:

--- a/src/ReCaptcha/ReCaptcha.php
+++ b/src/ReCaptcha/ReCaptcha.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -49,7 +47,7 @@ class ReCaptcha
      *
      * @var string
      */
-    public const VERSION = 'php_1.5.0';
+    public const VERSION = 'php_1.4.2';
 
     /**
      * URL for reCAPTCHA siteverify API.
@@ -137,19 +135,23 @@ class ReCaptcha
 
     /**
      * Shared secret for the site.
+     *
+     * @var string
      */
-    private string $secret;
+    private $secret;
 
     /**
      * Method used to communicate with service. Defaults to POST request.
+     *
+     * @var RequestMethod
      */
-    private RequestMethod $requestMethod;
+    private $requestMethod;
 
-    private ?string $hostname = null;
-    private ?string $apkPackageName = null;
-    private ?string $action = null;
-    private ?float $threshold = null;
-    private ?int $timeoutSeconds = null;
+    private $hostname;
+    private $apkPackageName;
+    private $action;
+    private $threshold;
+    private $timeoutSeconds;
 
     /**
      * Create a configured instance to use the reCAPTCHA service.
@@ -159,15 +161,19 @@ class ReCaptcha
      *
      * @throws \RuntimeException if $secret is invalid
      */
-    public function __construct(string $secret, ?RequestMethod $requestMethod = null)
+    public function __construct($secret, ?RequestMethod $requestMethod = null)
     {
-        if ('' === $secret) {
+        if (empty($secret)) {
             throw new \RuntimeException('No secret provided');
+        }
+
+        if (!is_string($secret)) {
+            throw new \RuntimeException('The provided secret must be a string');
         }
 
         $this->secret = $secret;
 
-        if (null !== $requestMethod) {
+        if (!is_null($requestMethod)) {
             $this->requestMethod = $requestMethod;
         } elseif (function_exists('curl_version')) {
             $this->requestMethod = new RequestMethod\CurlPost();
@@ -180,15 +186,15 @@ class ReCaptcha
      * Calls the reCAPTCHA siteverify API to verify whether the user passes
      * CAPTCHA test and additionally runs any specified additional checks.
      *
-     * @param string      $response the user response token provided by reCAPTCHA, verifying the user on your site
-     * @param null|string $remoteIp the end user's IP address
+     * @param string $response the user response token provided by reCAPTCHA, verifying the user on your site
+     * @param string $remoteIp the end user's IP address
      *
      * @return Response response from the service
      */
-    public function verify(string $response, ?string $remoteIp = null): Response
+    public function verify($response, $remoteIp = null)
     {
         // Discard empty solution submissions
-        if ('' === $response) {
+        if (empty($response)) {
             return new Response(false, [self::E_MISSING_INPUT_RESPONSE]);
         }
 
@@ -197,23 +203,23 @@ class ReCaptcha
         $initialResponse = Response::fromJson($rawResponse);
         $validationErrors = [];
 
-        if (null !== $this->hostname && 0 !== strcasecmp($this->hostname, $initialResponse->getHostname())) {
+        if (isset($this->hostname) && 0 !== strcasecmp($this->hostname, $initialResponse->getHostname())) {
             $validationErrors[] = self::E_HOSTNAME_MISMATCH;
         }
 
-        if (null !== $this->apkPackageName && 0 !== strcasecmp($this->apkPackageName, $initialResponse->getApkPackageName())) {
+        if (isset($this->apkPackageName) && 0 !== strcasecmp($this->apkPackageName, $initialResponse->getApkPackageName())) {
             $validationErrors[] = self::E_APK_PACKAGE_NAME_MISMATCH;
         }
 
-        if (null !== $this->action && 0 !== strcasecmp($this->action, $initialResponse->getAction())) {
+        if (isset($this->action) && 0 !== strcasecmp($this->action, $initialResponse->getAction())) {
             $validationErrors[] = self::E_ACTION_MISMATCH;
         }
 
-        if (null !== $this->threshold && $this->threshold > $initialResponse->getScore()) {
+        if (isset($this->threshold) && $this->threshold > $initialResponse->getScore()) {
             $validationErrors[] = self::E_SCORE_THRESHOLD_NOT_MET;
         }
 
-        if (null !== $this->timeoutSeconds) {
+        if (isset($this->timeoutSeconds)) {
             $challengeTs = strtotime($initialResponse->getChallengeTs());
 
             if ($challengeTs > 0 && time() - $challengeTs > $this->timeoutSeconds) {
@@ -244,7 +250,7 @@ class ReCaptcha
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setExpectedHostname(string $hostname): self
+    public function setExpectedHostname($hostname)
     {
         $this->hostname = $hostname;
 
@@ -258,7 +264,7 @@ class ReCaptcha
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setExpectedApkPackageName(string $apkPackageName): self
+    public function setExpectedApkPackageName($apkPackageName)
     {
         $this->apkPackageName = $apkPackageName;
 
@@ -273,7 +279,7 @@ class ReCaptcha
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setExpectedAction(string $action): self
+    public function setExpectedAction($action)
     {
         $this->action = $action;
 
@@ -288,9 +294,9 @@ class ReCaptcha
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setScoreThreshold(float $threshold): self
+    public function setScoreThreshold($threshold)
     {
-        $this->threshold = $threshold;
+        $this->threshold = floatval($threshold);
 
         return $this;
     }
@@ -302,7 +308,7 @@ class ReCaptcha
      *
      * @return ReCaptcha Current instance for fluent interface
      */
-    public function setChallengeTimeout(int $timeoutSeconds): self
+    public function setChallengeTimeout($timeoutSeconds)
     {
         $this->timeoutSeconds = $timeoutSeconds;
 

--- a/src/ReCaptcha/RequestMethod/Curl.php
+++ b/src/ReCaptcha/RequestMethod/Curl.php
@@ -35,19 +35,46 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace ReCaptcha;
+namespace ReCaptcha\RequestMethod;
 
 /**
- * Method used to send the request to the service.
+ * Convenience wrapper around the cURL functions to allow mocking.
  */
-interface RequestMethod
+class Curl
 {
     /**
-     * Submit the request with the specified parameters.
+     * @see http://php.net/curl_init
      *
-     * @param RequestParameters $params Request parameters
+     * @param string $url
      *
-     * @return string Body of the reCAPTCHA response
+     * @return resource cURL handle
      */
-    public function submit(RequestParameters $params);
+    public function init($url = null)
+    {
+        return curl_init($url);
+    }
+
+    /**
+     * @see http://php.net/curl_setopt_array
+     *
+     * @param resource $ch
+     *
+     * @return bool
+     */
+    public function setoptArray($ch, array $options)
+    {
+        return curl_setopt_array($ch, $options);
+    }
+
+    /**
+     * @see http://php.net/curl_exec
+     *
+     * @param resource $ch
+     *
+     * @return mixed
+     */
+    public function exec($ch)
+    {
+        return curl_exec($ch);
+    }
 }

--- a/src/ReCaptcha/RequestMethod/CurlPost.php
+++ b/src/ReCaptcha/RequestMethod/CurlPost.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -52,17 +50,28 @@ use ReCaptcha\RequestParameters;
 class CurlPost implements RequestMethod
 {
     /**
-     * URL for reCAPTCHA siteverify API.
+     * Curl connection to the reCAPTCHA service.
+     *
+     * @var Curl
      */
-    private string $siteVerifyUrl;
+    private $curl;
+
+    /**
+     * URL for reCAPTCHA siteverify API.
+     *
+     * @var string
+     */
+    private $siteVerifyUrl;
 
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|string $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param Curl   $curl          Curl resource
+     * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(?string $siteVerifyUrl = null)
+    public function __construct(?Curl $curl = null, $siteVerifyUrl = null)
     {
+        $this->curl = (is_null($curl)) ? new Curl() : $curl;
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
     }
 
@@ -73,9 +82,9 @@ class CurlPost implements RequestMethod
      *
      * @return string Body of the reCAPTCHA response
      */
-    public function submit(RequestParameters $params): string
+    public function submit(RequestParameters $params)
     {
-        $handle = curl_init($this->siteVerifyUrl);
+        $handle = $this->curl->init($this->siteVerifyUrl);
 
         $options = [
             CURLOPT_POST => true,
@@ -87,20 +96,15 @@ class CurlPost implements RequestMethod
             CURLOPT_HEADER => false,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => true,
-            CURLOPT_TIMEOUT => 60,
         ];
-        curl_setopt_array($handle, $options);
+        $this->curl->setoptArray($handle, $options);
 
-        try {
-            $response = curl_exec($handle);
+        $response = $this->curl->exec($handle);
 
-            if (is_string($response)) {
-                return $response;
-            }
-
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
-        } finally {
-            curl_close($handle);
+        if (false !== $response) {
+            return $response;
         }
+
+        return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
     }
 }

--- a/src/ReCaptcha/RequestMethod/Post.php
+++ b/src/ReCaptcha/RequestMethod/Post.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -50,15 +48,17 @@ class Post implements RequestMethod
 {
     /**
      * URL for reCAPTCHA siteverify API.
+     *
+     * @var string
      */
-    private string $siteVerifyUrl;
+    private $siteVerifyUrl;
 
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|string $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(?string $siteVerifyUrl = null)
+    public function __construct($siteVerifyUrl = null)
     {
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
     }
@@ -70,24 +70,21 @@ class Post implements RequestMethod
      *
      * @return string Body of the reCAPTCHA response
      */
-    public function submit(RequestParameters $params): string
+    public function submit(RequestParameters $params)
     {
         $options = [
-            'ssl' => [
-                'verify_peer' => true,
-                'verify_peer_name' => true,
-            ],
             'http' => [
                 'header' => "Content-type: application/x-www-form-urlencoded\r\n",
                 'method' => 'POST',
                 'content' => $params->toQueryString(),
-                'timeout' => 60,
+                // Force the peer to validate (not needed in 5.6.0+, but still works)
+                'verify_peer' => true,
             ],
         ];
         $context = stream_context_create($options);
         $response = file_get_contents($this->siteVerifyUrl, false, $context);
 
-        if (is_string($response)) {
+        if (false !== $response) {
             return $response;
         }
 

--- a/src/ReCaptcha/RequestMethod/Socket.php
+++ b/src/ReCaptcha/RequestMethod/Socket.php
@@ -35,19 +35,90 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-namespace ReCaptcha;
+namespace ReCaptcha\RequestMethod;
 
 /**
- * Method used to send the request to the service.
+ * Convenience wrapper around native socket and file functions to allow for
+ * mocking.
  */
-interface RequestMethod
+class Socket
 {
+    private $handle;
+
     /**
-     * Submit the request with the specified parameters.
+     * fsockopen.
      *
-     * @param RequestParameters $params Request parameters
+     * @see http://php.net/fsockopen
      *
-     * @return string Body of the reCAPTCHA response
+     * @param string $hostname
+     * @param int    $port
+     * @param int    $errno
+     * @param string $errstr
+     * @param float  $timeout
+     *
+     * @return resource
      */
-    public function submit(RequestParameters $params);
+    public function fsockopen($hostname, $port = -1, &$errno = 0, &$errstr = '', $timeout = null)
+    {
+        $this->handle = fsockopen($hostname, $port, $errno, $errstr, is_null($timeout) ? ini_get('default_socket_timeout') : $timeout);
+
+        if (false != $this->handle && 0 === $errno && '' === $errstr) {
+            return $this->handle;
+        }
+
+        return false;
+    }
+
+    /**
+     * fwrite.
+     *
+     * @see http://php.net/fwrite
+     *
+     * @param string $string
+     * @param int    $length
+     *
+     * @return bool|int
+     */
+    public function fwrite($string, $length = null)
+    {
+        return fwrite($this->handle, $string, is_null($length) ? strlen($string) : $length);
+    }
+
+    /**
+     * fgets.
+     *
+     * @see http://php.net/fgets
+     *
+     * @param int $length
+     *
+     * @return string
+     */
+    public function fgets($length = null)
+    {
+        return fgets($this->handle, $length);
+    }
+
+    /**
+     * feof.
+     *
+     * @see http://php.net/feof
+     *
+     * @return bool
+     */
+    public function feof()
+    {
+        return feof($this->handle);
+    }
+
+    /**
+     * fclose.
+     *
+     * @see http://php.net/fclose
+     *
+     * @return bool
+     */
+    public function fclose()
+    {
+        return fclose($this->handle);
+    }
 }

--- a/src/ReCaptcha/RequestMethod/SocketPost.php
+++ b/src/ReCaptcha/RequestMethod/SocketPost.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -50,15 +48,24 @@ use ReCaptcha\RequestParameters;
  */
 class SocketPost implements RequestMethod
 {
-    private string $siteVerifyUrl;
+    /**
+     * Socket to the reCAPTCHA service.
+     *
+     * @var Socket
+     */
+    private $socket;
+
+    private $siteVerifyUrl;
 
     /**
      * Only needed if you want to override the defaults.
      *
-     * @param null|string $siteVerifyUrl URL for reCAPTCHA siteverify API
+     * @param Socket $socket        optional socket, injectable for testing
+     * @param string $siteVerifyUrl URL for reCAPTCHA siteverify API
      */
-    public function __construct(?string $siteVerifyUrl = null)
+    public function __construct(?Socket $socket = null, $siteVerifyUrl = null)
     {
+        $this->socket = (is_null($socket)) ? new Socket() : $socket;
         $this->siteVerifyUrl = (is_null($siteVerifyUrl)) ? ReCaptcha::SITE_VERIFY_URL : $siteVerifyUrl;
     }
 
@@ -69,23 +76,13 @@ class SocketPost implements RequestMethod
      *
      * @return string Body of the reCAPTCHA response
      */
-    public function submit(RequestParameters $params): string
+    public function submit(RequestParameters $params)
     {
         $errno = 0;
         $errstr = '';
         $urlParsed = parse_url($this->siteVerifyUrl);
 
-        if (false === $urlParsed || !isset($urlParsed['host']) || !isset($urlParsed['path'])) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
-        }
-
-        $handle = fsockopen('ssl://'.$urlParsed['host'], 443, $errno, $errstr, 30);
-
-        if (false === $handle || 0 !== $errno || '' !== $errstr) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
-        }
-
-        if (false === stream_set_timeout($handle, 60)) {
+        if (false === $this->socket->fsockopen('ssl://'.$urlParsed['host'], 443, $errno, $errstr, 30)) {
             return '{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}';
         }
 
@@ -98,24 +95,20 @@ class SocketPost implements RequestMethod
         $request .= "Connection: close\r\n\r\n";
         $request .= $content."\r\n\r\n";
 
-        fwrite($handle, $request);
-        $response = stream_get_contents($handle);
+        $this->socket->fwrite($request);
+        $response = '';
 
-        fclose($handle);
-
-        if (!is_string($response)) {
-            $response = '';
+        while (!$this->socket->feof()) {
+            $response .= $this->socket->fgets(4096);
         }
 
-        if (1 !== preg_match('#^HTTP/1\.[01] 200 OK#', $response)) {
+        $this->socket->fclose();
+
+        if (0 !== strpos($response, 'HTTP/1.0 200 OK')) {
             return '{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}';
         }
 
         $parts = preg_split("#\n\\s*\n#Uis", $response);
-
-        if (!is_array($parts) || !isset($parts[1])) {
-            return '{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}';
-        }
 
         return $parts[1];
     }

--- a/src/ReCaptcha/RequestParameters.php
+++ b/src/ReCaptcha/RequestParameters.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -42,29 +40,58 @@ namespace ReCaptcha;
 /**
  * Stores and formats the parameters for the request to the reCAPTCHA service.
  */
-readonly class RequestParameters
+class RequestParameters
 {
+    /**
+     * The shared key between your site and reCAPTCHA.
+     *
+     * @var string
+     */
+    private $secret;
+
+    /**
+     * The user response token provided by reCAPTCHA, verifying the user on your site.
+     *
+     * @var string
+     */
+    private $response;
+
+    /**
+     * Remote user's IP address.
+     *
+     * @var string
+     */
+    private $remoteIp;
+
+    /**
+     * Client version.
+     *
+     * @var string
+     */
+    private $version;
+
     /**
      * Initialise parameters.
      *
-     * @param string      $secret   site secret
-     * @param string      $response value from g-captcha-response form field
-     * @param null|string $remoteIp user's IP address
-     * @param null|string $version  version of this client library
+     * @param string $secret   site secret
+     * @param string $response value from g-captcha-response form field
+     * @param string $remoteIp user's IP address
+     * @param string $version  version of this client library
      */
-    public function __construct(
-        private string $secret,
-        private string $response,
-        private ?string $remoteIp = null,
-        private ?string $version = null,
-    ) {}
+    public function __construct($secret, $response, $remoteIp = null, $version = null)
+    {
+        $this->secret = $secret;
+        $this->response = $response;
+        $this->remoteIp = $remoteIp;
+        $this->version = $version;
+    }
 
     /**
      * Array representation.
      *
-     * @return array<string, string> array formatted parameters
+     * @return array array formatted parameters
      */
-    public function toArray(): array
+    public function toArray()
     {
         $params = ['secret' => $this->secret, 'response' => $this->response];
 
@@ -84,7 +111,7 @@ readonly class RequestParameters
      *
      * @return string query string formatted parameters
      */
-    public function toQueryString(): string
+    public function toQueryString()
     {
         return http_build_query($this->toArray(), '', '&');
     }

--- a/src/ReCaptcha/Response.php
+++ b/src/ReCaptcha/Response.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -42,55 +40,105 @@ namespace ReCaptcha;
 /**
  * The response returned from the service.
  */
-readonly class Response
+class Response
 {
+    /**
+     * Success or failure.
+     *
+     * @var bool
+     */
+    private $success = false;
+
+    /**
+     * Error code strings.
+     *
+     * @var array
+     */
+    private $errorCodes = [];
+
+    /**
+     * The hostname of the site where the reCAPTCHA was solved.
+     *
+     * @var string
+     */
+    private $hostname;
+
+    /**
+     * Timestamp of the challenge load (ISO format yyyy-MM-dd'T'HH:mm:ssZZ).
+     *
+     * @var string
+     */
+    private $challengeTs;
+
+    /**
+     * APK package name.
+     *
+     * @var string
+     */
+    private $apkPackageName;
+
+    /**
+     * Score assigned to the request.
+     *
+     * @var float
+     */
+    private $score;
+
+    /**
+     * Action as specified by the page.
+     *
+     * @var string
+     */
+    private $action;
+
     /**
      * Constructor.
      *
-     * @param bool          $success        success or failure
-     * @param array<string> $errorCodes     error code strings
-     * @param string        $hostname       the hostname of the site where the reCAPTCHA was solved
-     * @param string        $challengeTs    timestamp of the challenge load (ISO format yyyy-MM-dd'T'HH:mm:ssZZ)
-     * @param string        $apkPackageName APK package name
-     * @param ?float        $score          score assigned to the request
-     * @param string        $action         action as specified by the page
+     * @param bool   $success
+     * @param string $hostname
+     * @param string $challengeTs
+     * @param string $apkPackageName
+     * @param float  $score
+     * @param string $action
      */
-    public function __construct(
-        private bool $success,
-        private array $errorCodes = [],
-        private string $hostname = '',
-        private string $challengeTs = '',
-        private string $apkPackageName = '',
-        private ?float $score = null,
-        private string $action = '',
-    ) {}
+    public function __construct($success, array $errorCodes = [], $hostname = '', $challengeTs = '', $apkPackageName = '', $score = null, $action = '')
+    {
+        $this->success = $success;
+        $this->hostname = $hostname;
+        $this->challengeTs = $challengeTs;
+        $this->apkPackageName = $apkPackageName;
+        $this->score = $score;
+        $this->action = $action;
+        $this->errorCodes = $errorCodes;
+    }
 
     /**
      * Build the response from the expected JSON returned by the service.
+     *
+     * @param string $json
+     *
+     * @return Response
      */
-    public static function fromJson(string $json): Response
+    public static function fromJson($json)
     {
         $responseData = json_decode($json, true);
 
-        if (!is_array($responseData)) {
+        if (!$responseData) {
             return new Response(false, [ReCaptcha::E_INVALID_JSON]);
         }
 
-        $hostname = isset($responseData['hostname']) && is_string($responseData['hostname']) ? $responseData['hostname'] : '';
-        $challengeTs = isset($responseData['challenge_ts']) && is_string($responseData['challenge_ts']) ? $responseData['challenge_ts'] : '';
-        $apkPackageName = isset($responseData['apk_package_name']) && is_string($responseData['apk_package_name']) ? $responseData['apk_package_name'] : '';
-        $score = isset($responseData['score']) && is_numeric($responseData['score']) ? floatval($responseData['score']) : null;
-        $action = isset($responseData['action']) && is_string($responseData['action']) ? $responseData['action'] : '';
+        $hostname = $responseData['hostname'] ?? '';
+        $challengeTs = $responseData['challenge_ts'] ?? '';
+        $apkPackageName = $responseData['apk_package_name'] ?? '';
+        $score = isset($responseData['score']) ? floatval($responseData['score']) : null;
+        $action = $responseData['action'] ?? '';
 
-        if (isset($responseData['success']) && true === $responseData['success']) {
+        if (isset($responseData['success']) && true == $responseData['success']) {
             return new Response(true, [], $hostname, $challengeTs, $apkPackageName, $score, $action);
         }
 
         if (isset($responseData['error-codes']) && is_array($responseData['error-codes'])) {
-            /** @var array<string> $errorCodes */
-            $errorCodes = $responseData['error-codes'];
-
-            return new Response(false, $errorCodes, $hostname, $challengeTs, $apkPackageName, $score, $action);
+            return new Response(false, $responseData['error-codes'], $hostname, $challengeTs, $apkPackageName, $score, $action);
         }
 
         return new Response(false, [ReCaptcha::E_UNKNOWN_ERROR], $hostname, $challengeTs, $apkPackageName, $score, $action);
@@ -98,8 +146,10 @@ readonly class Response
 
     /**
      * Is success?
+     *
+     * @return bool
      */
-    public function isSuccess(): bool
+    public function isSuccess()
     {
         return $this->success;
     }
@@ -107,49 +157,59 @@ readonly class Response
     /**
      * Get error codes.
      *
-     * @return array<string>
+     * @return array
      */
-    public function getErrorCodes(): array
+    public function getErrorCodes()
     {
         return $this->errorCodes;
     }
 
     /**
      * Get hostname.
+     *
+     * @return string
      */
-    public function getHostname(): string
+    public function getHostname()
     {
         return $this->hostname;
     }
 
     /**
      * Get challenge timestamp.
+     *
+     * @return string
      */
-    public function getChallengeTs(): string
+    public function getChallengeTs()
     {
         return $this->challengeTs;
     }
 
     /**
      * Get APK package name.
+     *
+     * @return string
      */
-    public function getApkPackageName(): string
+    public function getApkPackageName()
     {
         return $this->apkPackageName;
     }
 
     /**
      * Get score.
+     *
+     * @return float
      */
-    public function getScore(): ?float
+    public function getScore()
     {
         return $this->score;
     }
 
     /**
      * Get action.
+     *
+     * @return string
      */
-    public function getAction(): string
+    public function getAction()
     {
         return $this->action;
     }
@@ -167,7 +227,7 @@ readonly class Response
      *     error-codes: string[]
      * }
      */
-    public function toArray(): array
+    public function toArray()
     {
         return [
             'success' => $this->isSuccess(),

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -35,7 +35,7 @@
  */
 
 spl_autoload_register(function ($class) {
-    if (!str_starts_with($class, 'ReCaptcha\\')) {
+    if ('ReCaptcha\\' !== substr($class, 0, 10)) {
         /* If the class does not lie under the "ReCaptcha" namespace,
          * then we can exit immediately.
          */

--- a/tests/ReCaptcha/ReCaptchaTest.php
+++ b/tests/ReCaptcha/ReCaptchaTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -43,123 +41,53 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Global state for mocking functions in the ReCaptcha namespace.
- */
-class GlobalState
-{
-    public static ?bool $isCurlAvailable = null;
-}
-
-/**
- * Mock function_exists in the ReCaptcha namespace.
- */
-function function_exists(string $function): bool
-{
-    if ('curl_version' === $function && !is_null(GlobalState::$isCurlAvailable)) {
-        return GlobalState::$isCurlAvailable;
-    }
-
-    return \function_exists($function);
-}
-
-/**
  * @internal
  *
  * @coversNothing
  */
 class ReCaptchaTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        GlobalState::$isCurlAvailable = null;
-    }
-
     #[DataProvider('invalidSecretProvider')]
-    public function testExceptionThrownOnInvalidSecretType(mixed $invalid): void
+    public function testExceptionThrownOnInvalidSecret($invalid)
     {
-        $this->expectException(\TypeError::class);
-
-        /** @phpstan-ignore argument.type */
+        $this->expectException(\RuntimeException::class);
         $rc = new ReCaptcha($invalid);
     }
 
-    /**
-     * @return array<int, array<int, mixed>>
-     */
-    public static function invalidSecretProvider(): array
-    {
-        return [
-            [null],
-            [new \stdClass()],
-            [[]],
-            [0],
-        ];
-    }
-
-    #[DataProvider('emptySecretProvider')]
-    public function testExceptionThrownOnEmptySecret(mixed $emptySecret): void
-    {
-        $this->expectException(\RuntimeException::class);
-
-        /** @phpstan-ignore argument.type */
-        $rc = new ReCaptcha($emptySecret);
-    }
-
-    /**
-     * @return array<int, array<int, mixed>>
-     */
-    public static function emptySecretProvider(): array
+    public static function invalidSecretProvider()
     {
         return [
             [''],
+            [null],
+            [0],
+            [new \stdClass()],
+            [[]],
         ];
     }
 
-    public function testVerifyReturnsErrorOnMissingResponse(): void
+    public function testVerifyReturnsErrorOnMissingResponse()
     {
         $rc = new ReCaptcha('secret');
         $response = $rc->verify('');
         $this->assertFalse($response->isSuccess());
-        $this->assertEquals([ReCaptcha::E_MISSING_INPUT_RESPONSE], $response->getErrorCodes());
+        $this->assertEquals([Recaptcha::E_MISSING_INPUT_RESPONSE], $response->getErrorCodes());
     }
 
-    public function testZeroAsStringIsValidSecret(): void
+    public function testDefaultRequestMethod()
     {
-        $rc = new ReCaptcha('0');
-        $this->assertInstanceOf(ReCaptcha::class, $rc);
-    }
-
-    public function testZeroAsStringIsValidResponse(): void
-    {
-        $method = $this->getMockRequestMethod('{"success": true}');
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->verify('0');
-        $this->assertTrue($response->isSuccess());
-    }
-
-    public function testDefaultRequestMethodWithCurl(): void
-    {
-        GlobalState::$isCurlAvailable = true;
         $rc = new ReCaptcha('secret');
         $reflection = new \ReflectionClass($rc);
         $property = $reflection->getProperty('requestMethod');
         $requestMethod = $property->getValue($rc);
 
-        $this->assertInstanceOf(RequestMethod\CurlPost::class, $requestMethod);
+        if (function_exists('curl_version')) {
+            $this->assertInstanceOf(RequestMethod\CurlPost::class, $requestMethod);
+        } else {
+            $this->assertInstanceOf(RequestMethod\Post::class, $requestMethod);
+        }
     }
 
-    public function testDefaultRequestMethodWithoutCurl(): void
-    {
-        GlobalState::$isCurlAvailable = false;
-        $rc = new ReCaptcha('secret');
-        $reflection = new \ReflectionClass($rc);
-        $property = $reflection->getProperty('requestMethod');
-        $requestMethod = $property->getValue($rc);
-
-        $this->assertInstanceOf(RequestMethod\Post::class, $requestMethod);
-    }
-
-    public function testVerifyReturnsResponse(): void
+    public function testVerifyReturnsResponse()
     {
         $method = $this->getMockRequestMethod('{"success": true}');
         $rc = new ReCaptcha('secret', $method);
@@ -167,7 +95,7 @@ class ReCaptchaTest extends TestCase
         $this->assertTrue($response->isSuccess());
     }
 
-    public function testVerifyReturnsInitialResponseWithoutAdditionalChecks(): void
+    public function testVerifyReturnsInitialResponseWithoutAdditionalChecks()
     {
         $method = $this->getMockRequestMethod('{"success": true}');
         $rc = new ReCaptcha('secret', $method);
@@ -175,7 +103,7 @@ class ReCaptchaTest extends TestCase
         $this->assertEquals($initialResponse, $rc->verify('response'));
     }
 
-    public function testVerifyHostnameMatch(): void
+    public function testVerifyHostnameMatch()
     {
         $method = $this->getMockRequestMethod('{"success": true, "hostname": "host.name"}');
         $rc = new ReCaptcha('secret', $method);
@@ -183,7 +111,7 @@ class ReCaptchaTest extends TestCase
         $this->assertTrue($response->isSuccess());
     }
 
-    public function testVerifyHostnameMisMatch(): void
+    public function testVerifyHostnameMisMatch()
     {
         $method = $this->getMockRequestMethod('{"success": true, "hostname": "host.NOTname"}');
         $rc = new ReCaptcha('secret', $method);
@@ -192,20 +120,7 @@ class ReCaptchaTest extends TestCase
         $this->assertEquals([ReCaptcha::E_HOSTNAME_MISMATCH], $response->getErrorCodes());
     }
 
-    public function testVerifyHostnameMatchCaseInsensitive(): void
-    {
-        $method = $this->getMockRequestMethod('{"success": true, "hostname": "host.name"}');
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setExpectedHostname('HOST.NAME')->verify('response');
-        $this->assertTrue($response->isSuccess());
-
-        $method = $this->getMockRequestMethod('{"success": true, "hostname": "HOST.NAME"}');
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setExpectedHostname('host.name')->verify('response');
-        $this->assertTrue($response->isSuccess());
-    }
-
-    public function testVerifyApkPackageNameMatch(): void
+    public function testVerifyApkPackageNameMatch()
     {
         $method = $this->getMockRequestMethod('{"success": true, "apk_package_name": "apk.name"}');
         $rc = new ReCaptcha('secret', $method);
@@ -213,7 +128,7 @@ class ReCaptchaTest extends TestCase
         $this->assertTrue($response->isSuccess());
     }
 
-    public function testVerifyApkPackageNameMisMatch(): void
+    public function testVerifyApkPackageNameMisMatch()
     {
         $method = $this->getMockRequestMethod('{"success": true, "apk_package_name": "apk.NOTname"}');
         $rc = new ReCaptcha('secret', $method);
@@ -222,7 +137,7 @@ class ReCaptchaTest extends TestCase
         $this->assertEquals([ReCaptcha::E_APK_PACKAGE_NAME_MISMATCH], $response->getErrorCodes());
     }
 
-    public function testVerifyActionMatch(): void
+    public function testVerifyActionMatch()
     {
         $method = $this->getMockRequestMethod('{"success": true, "action": "action/name"}');
         $rc = new ReCaptcha('secret', $method);
@@ -230,7 +145,7 @@ class ReCaptchaTest extends TestCase
         $this->assertTrue($response->isSuccess());
     }
 
-    public function testVerifyActionMisMatch(): void
+    public function testVerifyActionMisMatch()
     {
         $method = $this->getMockRequestMethod('{"success": true, "action": "action/NOTname"}');
         $rc = new ReCaptcha('secret', $method);
@@ -239,62 +154,54 @@ class ReCaptchaTest extends TestCase
         $this->assertEquals([ReCaptcha::E_ACTION_MISMATCH], $response->getErrorCodes());
     }
 
-    public function testVerifyAboveThreshold(): void
+    public function testVerifyAboveThreshold()
     {
         $method = $this->getMockRequestMethod('{"success": true, "score": "0.9"}');
         $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setScoreThreshold(0.5)->verify('response');
+        $response = $rc->setScoreThreshold('0.5')->verify('response');
         $this->assertTrue($response->isSuccess());
     }
 
-    public function testVerifyBelowThreshold(): void
+    public function testVerifyBelowThreshold()
     {
         $method = $this->getMockRequestMethod('{"success": true, "score": "0.1"}');
         $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setScoreThreshold(0.5)->verify('response');
+        $response = $rc->setScoreThreshold('0.5')->verify('response');
         $this->assertFalse($response->isSuccess());
         $this->assertEquals([ReCaptcha::E_SCORE_THRESHOLD_NOT_MET], $response->getErrorCodes());
     }
 
-    public function testVerifyWithinTimeout(): void
+    public function testVerifyWithinTimeout()
     {
         // Responses come back like 2018-07-31T13:48:41Z
         $challengeTs = date('Y-M-d\TH:i:s\Z', time());
         $method = $this->getMockRequestMethod('{"success": true, "challenge_ts": "'.$challengeTs.'"}');
         $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setChallengeTimeout(1000)->verify('response');
+        $response = $rc->setChallengeTimeout('1000')->verify('response');
         $this->assertTrue($response->isSuccess());
     }
 
-    public function testVerifyOverTimeout(): void
+    public function testVerifyOverTimeout()
     {
         // Responses come back like 2018-07-31T13:48:41Z
         $challengeTs = date('Y-M-d\TH:i:s\Z', time() - 600);
         $method = $this->getMockRequestMethod('{"success": true, "challenge_ts": "'.$challengeTs.'"}');
         $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setChallengeTimeout(60)->verify('response');
+        $response = $rc->setChallengeTimeout('60')->verify('response');
         $this->assertFalse($response->isSuccess());
         $this->assertEquals([ReCaptcha::E_CHALLENGE_TIMEOUT], $response->getErrorCodes());
     }
 
-    public function testVerifyWithInvalidChallengeTsAndTimeout(): void
-    {
-        $method = $this->getMockRequestMethod('{"success": true, "challenge_ts": "invalid-timestamp"}');
-        $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setChallengeTimeout(60)->verify('response');
-        $this->assertTrue($response->isSuccess());
-    }
-
-    public function testVerifyMergesErrors(): void
+    public function testVerifyMergesErrors()
     {
         $method = $this->getMockRequestMethod('{"success": false, "error-codes": ["initial-error"], "score": "0.1"}');
         $rc = new ReCaptcha('secret', $method);
-        $response = $rc->setScoreThreshold(0.5)->verify('response');
+        $response = $rc->setScoreThreshold('0.5')->verify('response');
         $this->assertFalse($response->isSuccess());
         $this->assertEquals(['initial-error', ReCaptcha::E_SCORE_THRESHOLD_NOT_MET], $response->getErrorCodes());
     }
 
-    private function getMockRequestMethod(string $responseJson): RequestMethod
+    private function getMockRequestMethod($responseJson)
     {
         $method = $this->createStub(RequestMethod::class);
         $method->method('submit')

--- a/tests/ReCaptcha/RequestMethod/CurlPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/CurlPostTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -44,59 +42,6 @@ use ReCaptcha\ReCaptcha;
 use ReCaptcha\RequestParameters;
 
 /**
- * Global state for mocking curl functions.
- */
-class CurlPostGlobalState
-{
-    public static ?string $initUrl = null;
-
-    /**
-     * @var null|array<int, mixed>
-     */
-    public static ?array $setoptArrayOptions = null;
-
-    public static bool|string $execResponse = 'RESPONSEBODY';
-}
-
-/**
- * Mock curl_init in the ReCaptcha\RequestMethod namespace.
- */
-function curl_init(?string $url = null): \stdClass
-{
-    CurlPostGlobalState::$initUrl = $url;
-
-    return new \stdClass();
-}
-
-/**
- * Mock curl_setopt_array in the ReCaptcha\RequestMethod namespace.
- *
- * @param array<int, mixed> $options
- */
-function curl_setopt_array(\stdClass $ch, array $options): bool
-{
-    CurlPostGlobalState::$setoptArrayOptions = $options;
-
-    return true;
-}
-
-/**
- * Mock curl_exec in the ReCaptcha\RequestMethod namespace.
- */
-function curl_exec(\stdClass $ch): bool|string
-{
-    return CurlPostGlobalState::$execResponse;
-}
-
-/**
- * Mock curl_close in the ReCaptcha\RequestMethod namespace.
- */
-function curl_close(\stdClass $ch): void
-{
-    // no-op mock
-}
-
-/**
  * @internal
  *
  * @coversNothing
@@ -105,40 +50,85 @@ class CurlPostTest extends TestCase
 {
     protected function setUp(): void
     {
-        CurlPostGlobalState::$initUrl = null;
-        CurlPostGlobalState::$setoptArrayOptions = null;
-        CurlPostGlobalState::$execResponse = 'RESPONSEBODY';
+        if (!extension_loaded('curl')) {
+            $this->markTestSkipped(
+                'The cURL extension is not available.'
+            );
+        }
     }
 
-    public function testSubmit(): void
+    public function testSubmit()
     {
-        $pc = new CurlPost();
+        $curl = $this->getMockBuilder(Curl::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $curl->expects($this->once())
+            ->method('init')
+            ->willReturn(new \stdClass())
+        ;
+        $curl->expects($this->once())
+            ->method('setoptArray')
+            ->willReturn(true)
+        ;
+        $curl->expects($this->once())
+            ->method('exec')
+            ->willReturn('RESPONSEBODY')
+        ;
+
+        $pc = new CurlPost($curl);
         $response = $pc->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals(ReCaptcha::SITE_VERIFY_URL, CurlPostGlobalState::$initUrl);
-
-        /** @var array<int, mixed> $options */
-        $options = CurlPostGlobalState::$setoptArrayOptions;
-        $this->assertTrue($options[CURLOPT_POST]);
         $this->assertEquals('RESPONSEBODY', $response);
     }
 
-    public function testOverrideSiteVerifyUrl(): void
+    public function testOverrideSiteVerifyUrl()
     {
         $url = 'OVERRIDE';
-        $pc = new CurlPost($url);
-        $response = $pc->submit(new RequestParameters('secret', 'response'));
 
-        $this->assertEquals($url, CurlPostGlobalState::$initUrl);
+        $curl = $this->getMockBuilder(Curl::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $curl->expects($this->once())
+            ->method('init')
+            ->with($url)
+            ->willReturn(new \stdClass())
+        ;
+        $curl->expects($this->once())
+            ->method('setoptArray')
+            ->willReturn(true)
+        ;
+        $curl->expects($this->once())
+            ->method('exec')
+            ->willReturn('RESPONSEBODY')
+        ;
+
+        $pc = new CurlPost($curl, $url);
+        $response = $pc->submit(new RequestParameters('secret', 'response'));
         $this->assertEquals('RESPONSEBODY', $response);
     }
 
-    public function testConnectionFailureReturnsError(): void
+    public function testConnectionFailureReturnsError()
     {
-        CurlPostGlobalState::$execResponse = false;
-        $pc = new CurlPost();
-        $response = $pc->submit(new RequestParameters('secret', 'response'));
+        $curl = $this->getMockBuilder(Curl::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $curl->expects($this->once())
+            ->method('init')
+            ->willReturn(new \stdClass())
+        ;
+        $curl->expects($this->once())
+            ->method('setoptArray')
+            ->willReturn(true)
+        ;
+        $curl->expects($this->once())
+            ->method('exec')
+            ->willReturn(false)
+        ;
 
+        $pc = new CurlPost($curl);
+        $response = $pc->submit(new RequestParameters('secret', 'response'));
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
     }
 }

--- a/tests/ReCaptcha/RequestMethod/PostTest.php
+++ b/tests/ReCaptcha/RequestMethod/PostTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -50,12 +48,9 @@ use ReCaptcha\RequestParameters;
  */
 class PostTest extends TestCase
 {
-    /**
-     * @var null|callable
-     */
     public static $assert;
-    protected RequestParameters $parameters;
-    protected int $runcount = 0;
+    protected $parameters;
+    protected $runcount = 0;
 
     public function setUp(): void
     {
@@ -67,7 +62,7 @@ class PostTest extends TestCase
         self::$assert = null;
     }
 
-    public function testHTTPContextOptions(): void
+    public function testHTTPContextOptions()
     {
         $req = new Post();
         self::$assert = [$this, 'httpContextOptionsCallback'];
@@ -75,7 +70,15 @@ class PostTest extends TestCase
         $this->assertEquals(1, $this->runcount, 'The assertion was ran');
     }
 
-    public function testOverrideVerifyUrl(): void
+    public function testSSLContextOptions()
+    {
+        $req = new Post();
+        self::$assert = [$this, 'sslContextOptionsCallback'];
+        $req->submit($this->parameters);
+        $this->assertEquals(1, $this->runcount, 'The assertion was ran');
+    }
+
+    public function testOverrideVerifyUrl()
     {
         $req = new Post('https://over.ride/some/path');
         self::$assert = [$this, 'overrideUrlOptions'];
@@ -83,7 +86,7 @@ class PostTest extends TestCase
         $this->assertEquals(1, $this->runcount, 'The assertion was ran');
     }
 
-    public function testConnectionFailureReturnsError(): void
+    public function testConnectionFailureReturnsError()
     {
         $req = new Post('https://bad.connection/');
         self::$assert = [$this, 'connectionFailureResponse'];
@@ -91,107 +94,61 @@ class PostTest extends TestCase
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
     }
 
-    public function connectionFailureResponse(): bool
+    public function connectionFailureResponse()
     {
         return false;
     }
 
-    /**
-     * @param array<int, mixed> $args
-     */
-    public function overrideUrlOptions(array $args): void
+    public function overrideUrlOptions(array $args)
     {
         ++$this->runcount;
         $this->assertEquals('https://over.ride/some/path', $args[0]);
     }
 
-    /**
-     * @param array<int, mixed> $args
-     */
-    public function httpContextOptionsCallback(array $args): void
+    public function httpContextOptionsCallback(array $args)
     {
         ++$this->runcount;
         $this->assertCommonOptions($args);
 
-        /** @var resource $context */
-        $context = $args[2];
-        $options = stream_context_get_options($context);
+        $options = stream_context_get_options($args[2]);
         $this->assertArrayHasKey('http', $options);
-        $this->assertArrayHasKey('ssl', $options);
 
-        /** @var array<string, mixed> $httpOptions */
-        $httpOptions = $options['http'];
+        $this->assertArrayHasKey('method', $options['http']);
+        $this->assertEquals('POST', $options['http']['method']);
 
-        /** @var array<string, mixed> $sslOptions */
-        $sslOptions = $options['ssl'];
+        $this->assertArrayHasKey('content', $options['http']);
+        $this->assertEquals($this->parameters->toQueryString(), $options['http']['content']);
 
-        $this->assertArrayHasKey('method', $httpOptions);
-        $this->assertEquals('POST', $httpOptions['method']);
-
-        $this->assertArrayHasKey('content', $httpOptions);
-        $this->assertEquals($this->parameters->toQueryString(), $httpOptions['content']);
-
-        $this->assertArrayHasKey('header', $httpOptions);
-
-        /** @var string $header */
-        $header = $httpOptions['header'];
-        $this->assertStringContainsStringIgnoringCase('Content-type: application/x-www-form-urlencoded', $header);
-
-        $this->assertArrayHasKey('timeout', $httpOptions);
-        $this->assertEquals(60, $httpOptions['timeout']);
-
-        $this->assertArrayHasKey('verify_peer', $sslOptions);
-        $this->assertTrue((bool) $sslOptions['verify_peer']);
-        $this->assertArrayHasKey('verify_peer_name', $sslOptions);
-        $this->assertTrue((bool) $sslOptions['verify_peer_name']);
+        $this->assertArrayHasKey('header', $options['http']);
+        $this->assertStringContainsStringIgnoringCase('Content-type: application/x-www-form-urlencoded', $options['http']['header']);
     }
 
-    /**
-     * @param array<int, mixed> $args
-     */
-    protected function assertCommonOptions(array $args): void
+    public function sslContextOptionsCallback(array $args)
+    {
+        ++$this->runcount;
+        $this->assertCommonOptions($args);
+
+        $options = stream_context_get_options($args[2]);
+        $this->assertArrayHasKey('http', $options);
+        $this->assertArrayHasKey('verify_peer', $options['http']);
+        $this->assertTrue($options['http']['verify_peer']);
+    }
+
+    protected function assertCommonOptions(array $args)
     {
         $this->assertCount(3, $args);
-
-        /** @var string $url */
-        $url = $args[0];
-        $this->assertStringStartsWith('https://www.google.com/', $url);
+        $this->assertStringStartsWith('https://www.google.com/', $args[0]);
         $this->assertFalse($args[1]);
         $this->assertTrue(is_resource($args[2]), 'The context options should be a resource');
     }
 }
 
-function file_get_contents(string $filename, bool $use_include_path = false, mixed $context = null, int $offset = 0, ?int $length = null): false|string
+function file_get_contents()
 {
-    $args = func_get_args();
     if (PostTest::$assert) {
-        /** @var callable $assert */
-        $assert = PostTest::$assert;
-        $result = call_user_func($assert, $args);
-        if (null === $result) {
-            return '';
-        }
-
-        if (is_string($result)) {
-            return $result;
-        }
-
-        if (false === $result) {
-            return $result;
-        }
-
-        return false;
+        return call_user_func(PostTest::$assert, func_get_args());
     }
 
     // Since we can't represent maxlen in userland...
-    $result = call_user_func_array('\file_get_contents', $args);
-    if (is_string($result)) {
-        return $result;
-    }
-
-    if (false === $result) {
-        return $result;
-    }
-
-    return false;
+    return call_user_func_array('file_get_contents', func_get_args());
 }

--- a/tests/ReCaptcha/RequestMethod/SocketPostTest.php
+++ b/tests/ReCaptcha/RequestMethod/SocketPostTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -44,277 +42,107 @@ use ReCaptcha\ReCaptcha;
 use ReCaptcha\RequestParameters;
 
 /**
- * Global state for mocking socket functions.
- */
-class SocketPostGlobalState
-{
-    public static ?string $fsockopenHostname = null;
-    public static int $fsockopenErrno = 0;
-    public static string $fsockopenErrstr = '';
-    public static bool $fsockopenSuccess = true;
-    public static string $fwriteData = '';
-
-    /**
-     * @var array<int, false|string>
-     */
-    public static array $fgetsResponses = [];
-    public static int $feofCount = 0;
-    public static bool $fcloseCalled = false;
-    public static bool $streamSetTimeoutSuccess = true;
-}
-
-/**
- * Mock fsockopen in the ReCaptcha\RequestMethod namespace.
- */
-function fsockopen(string $hostname, int $port = -1, int &$errno = 0, string &$errstr = '', ?float $timeout = null): false|\stdClass
-{
-    SocketPostGlobalState::$fsockopenHostname = $hostname;
-    $errno = SocketPostGlobalState::$fsockopenErrno;
-    $errstr = SocketPostGlobalState::$fsockopenErrstr;
-
-    return SocketPostGlobalState::$fsockopenSuccess ? new \stdClass() : false;
-}
-
-/**
- * Mock fwrite in the ReCaptcha\RequestMethod namespace.
- */
-function fwrite(\stdClass $handle, string $string, ?int $length = null): int
-{
-    SocketPostGlobalState::$fwriteData .= $string;
-
-    return strlen($string);
-}
-
-/**
- * Mock stream_get_contents in the ReCaptcha\RequestMethod namespace.
- */
-function stream_get_contents(\stdClass $handle, ?int $length = null, int $offset = -1): false|string
-{
-    if (empty(SocketPostGlobalState::$fgetsResponses)) {
-        return false;
-    }
-
-    $result = '';
-    foreach (SocketPostGlobalState::$fgetsResponses as $response) {
-        if (false !== $response) {
-            $result .= $response;
-        }
-    }
-    SocketPostGlobalState::$fgetsResponses = [];
-
-    return $result;
-}
-
-/**
- * Mock stream_set_timeout in the ReCaptcha\RequestMethod namespace.
- */
-function stream_set_timeout(\stdClass $handle, int $seconds, int $microseconds = 0): bool
-{
-    return SocketPostGlobalState::$streamSetTimeoutSuccess;
-}
-
-/**
- * Mock fclose in the ReCaptcha\RequestMethod namespace.
- */
-function fclose(\stdClass $handle): bool
-{
-    SocketPostGlobalState::$fcloseCalled = true;
-
-    return true;
-}
-
-/**
  * @internal
  *
  * @coversNothing
  */
 class SocketPostTest extends TestCase
 {
-    protected function setUp(): void
+    public function testSubmitSuccess()
     {
-        SocketPostGlobalState::$fsockopenHostname = null;
-        SocketPostGlobalState::$fsockopenErrno = 0;
-        SocketPostGlobalState::$fsockopenErrstr = '';
-        SocketPostGlobalState::$fsockopenSuccess = true;
-        SocketPostGlobalState::$fwriteData = '';
-        SocketPostGlobalState::$fgetsResponses = [];
-        SocketPostGlobalState::$fcloseCalled = false;
-        SocketPostGlobalState::$streamSetTimeoutSuccess = true;
-    }
+        $socket = $this->createMock(Socket::class);
+        $socket->expects($this->once())
+            ->method('fsockopen')
+            ->willReturn(true)
+        ;
+        $socket->expects($this->once())
+            ->method('fwrite')
+        ;
+        $socket->expects($this->once())
+            ->method('fgets')
+            ->willReturn("HTTP/1.0 200 OK\n\nRESPONSEBODY")
+        ;
+        $socket->expects($this->exactly(2))
+            ->method('feof')
+            ->willReturnOnConsecutiveCalls(false, true)
+        ;
+        $socket->expects($this->once())
+            ->method('fclose')
+            ->willReturn(true)
+        ;
 
-    public function testSubmit(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('ssl://www.google.com', SocketPostGlobalState::$fsockopenHostname);
-        $this->assertStringContainsString('secret=secret', SocketPostGlobalState::$fwriteData);
-        $this->assertStringContainsString('response=response', SocketPostGlobalState::$fwriteData);
+        $ps = new SocketPost($socket);
+        $response = $ps->submit(new RequestParameters('secret', 'response', 'remoteip', 'version'));
         $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
     }
 
-    public function testOverrideSiteVerifyUrl(): void
+    public function testOverrideSiteVerifyUrl()
     {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
+        $socket = $this->createMock(Socket::class);
+        $socket->expects($this->once())
+            ->method('fsockopen')
+            ->with('ssl://over.ride', 443, 0, '', 30)
+            ->willReturn(true)
+        ;
+        $socket->expects($this->once())
+            ->method('fwrite')
+            ->with($this->matchesRegularExpression('/^POST \/some\/path.*Host: over\.ride/s'))
+        ;
+        $socket->expects($this->once())
+            ->method('fgets')
+            ->willReturn("HTTP/1.0 200 OK\n\nRESPONSEBODY")
+        ;
+        $socket->expects($this->exactly(2))
+            ->method('feof')
+            ->willReturnOnConsecutiveCalls(false, true)
+        ;
+        $socket->expects($this->once())
+            ->method('fclose')
+            ->willReturn(true)
+        ;
 
-        $url = 'https://custom.recaptcha.net/recaptcha/api/siteverify';
-        $sp = new SocketPost($url);
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('ssl://custom.recaptcha.net', SocketPostGlobalState::$fsockopenHostname);
-        $this->assertStringContainsString('POST /recaptcha/api/siteverify HTTP/1.0', SocketPostGlobalState::$fwriteData);
-        $this->assertStringContainsString('secret=secret', SocketPostGlobalState::$fwriteData);
-        $this->assertStringContainsString('response=response', SocketPostGlobalState::$fwriteData);
+        $ps = new SocketPost($socket, 'https://over.ride/some/path');
+        $response = $ps->submit(new RequestParameters('secret', 'response', 'remoteip', 'version'));
         $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
     }
 
-    public function testSubmitReturnsResponseWhenHttp11(): void
+    public function testSubmitBadResponse()
     {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.1 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
+        $socket = $this->createMock(Socket::class);
+        $socket->expects($this->once())
+            ->method('fsockopen')
+            ->willReturn(true)
+        ;
+        $socket->expects($this->once())
+            ->method('fwrite')
+        ;
+        $socket->expects($this->once())
+            ->method('fgets')
+            ->willReturn('HTTP/1.0 500 NOPEn\nBOBBINS')
+        ;
+        $socket->expects($this->exactly(2))
+            ->method('feof')
+            ->willReturnOnConsecutiveCalls(false, true)
+        ;
+        $socket->expects($this->once())
+            ->method('fclose')
+            ->willReturn(true)
+        ;
 
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
+        $ps = new SocketPost($socket);
+        $response = $ps->submit(new RequestParameters('secret', 'response', 'remoteip', 'version'));
+        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
     }
 
-    public function testStreamTimeoutFailureReturnsError(): void
+    public function testConnectionFailureReturnsError()
     {
-        SocketPostGlobalState::$streamSetTimeoutSuccess = false;
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
+        $socket = $this->createMock(Socket::class);
+        $socket->expects($this->once())
+            ->method('fsockopen')
+            ->willReturn(false)
+        ;
+        $ps = new SocketPost($socket);
+        $response = $ps->submit(new RequestParameters('secret', 'response', 'remoteip', 'version'));
         $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
-    }
-
-    public function testConnectionFailureWithValidHandleReturnsError(): void
-    {
-        SocketPostGlobalState::$fsockopenSuccess = true;
-        SocketPostGlobalState::$fsockopenErrno = 1;
-        SocketPostGlobalState::$fsockopenErrstr = 'Connection refused';
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
-    }
-
-    public function testUrlFailureReturnsError(): void
-    {
-        $sp = new SocketPost('invalid_url');
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
-    }
-
-    public function testSubmitWithFgetsFailure(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            false,
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('RESPONSEBODY', $response);
-        $this->assertTrue(SocketPostGlobalState::$fcloseCalled);
-    }
-
-    public function testMalformedResponseReturnsError(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
-    }
-
-    public function testConnectionFailureReturnsError(): void
-    {
-        SocketPostGlobalState::$fsockopenSuccess = false;
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_CONNECTION_FAILED.'"]}', $response);
-    }
-
-    public function testBadResponseReturnsError(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.0 500 Internal Server Error\r\n",
-            "\r\n",
-            'FAIL',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
-    }
-
-    public function testStreamGetContentsReturnsFalse(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
-    }
-
-    public function testBadResponseReturnsErrorWhenHttp11(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/1.1 500 Internal Server Error\r\n",
-            "\r\n",
-            'FAIL',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
-    }
-
-    public function testBadResponseReturnsErrorWhenHttp2(): void
-    {
-        SocketPostGlobalState::$fgetsResponses = [
-            "HTTP/2.0 200 OK\r\n",
-            "Content-Type: application/json\r\n",
-            "\r\n",
-            'RESPONSEBODY',
-        ];
-
-        $sp = new SocketPost();
-        $response = $sp->submit(new RequestParameters('secret', 'response'));
-
-        $this->assertEquals('{"success": false, "error-codes": ["'.ReCaptcha::E_BAD_RESPONSE.'"]}', $response);
     }
 }

--- a/tests/ReCaptcha/RequestParametersTest.php
+++ b/tests/ReCaptcha/RequestParametersTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -49,42 +47,29 @@ use PHPUnit\Framework\TestCase;
  */
 class RequestParametersTest extends TestCase
 {
-    /**
-     * @param array<string, string> $expectedArray
-     */
     #[DataProvider('provideValidData')]
-    public function testToArray(string $secret, string $response, ?string $remoteIp, ?string $version, array $expectedArray, string $expectedQuery): void
+    public function testToArray($secret, $response, $remoteIp, $version, $expectedArray, $expectedQuery)
     {
         $params = new RequestParameters($secret, $response, $remoteIp, $version);
         $this->assertEquals($params->toArray(), $expectedArray);
     }
 
-    /**
-     * @param array<string, string> $expectedArray
-     */
     #[DataProvider('provideValidData')]
-    public function testToQueryString(string $secret, string $response, ?string $remoteIp, ?string $version, array $expectedArray, string $expectedQuery): void
+    public function testToQueryString($secret, $response, $remoteIp, $version, $expectedArray, $expectedQuery)
     {
         $params = new RequestParameters($secret, $response, $remoteIp, $version);
         $this->assertEquals($params->toQueryString(), $expectedQuery);
     }
 
-    /**
-     * @return array<int, array{0: string, 1: string, 2: null|string, 3: null|string, 4: array<string, string>, 5: string}>
-     */
-    public static function provideValidData(): array
+    public static function provideValidData()
     {
         return [
-            [
-                'SECRET', 'RESPONSE', 'REMOTEIP', 'VERSION',
+            ['SECRET', 'RESPONSE', 'REMOTEIP', 'VERSION',
                 ['secret' => 'SECRET', 'response' => 'RESPONSE', 'remoteip' => 'REMOTEIP', 'version' => 'VERSION'],
-                'secret=SECRET&response=RESPONSE&remoteip=REMOTEIP&version=VERSION',
-            ],
-            [
-                'SECRET', 'RESPONSE', null, null,
+                'secret=SECRET&response=RESPONSE&remoteip=REMOTEIP&version=VERSION'],
+            ['SECRET', 'RESPONSE', null, null,
                 ['secret' => 'SECRET', 'response' => 'RESPONSE'],
-                'secret=SECRET&response=RESPONSE',
-            ],
+                'secret=SECRET&response=RESPONSE'],
         ];
     }
 }

--- a/tests/ReCaptcha/ResponseTest.php
+++ b/tests/ReCaptcha/ResponseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This is a PHP library that handles calling reCAPTCHA.
  *
@@ -49,26 +47,20 @@ use PHPUnit\Framework\TestCase;
  */
 class ResponseTest extends TestCase
 {
-    /**
-     * @param array<string> $errorCodes
-     */
     #[DataProvider('provideJson')]
-    public function testFromJson(string $json, bool $success, array $errorCodes, ?string $hostname, ?string $challengeTs, ?string $apkPackageName, ?float $score, ?string $action): void
+    public function testFromJson($json, $success, $errorCodes, $hostname, $challengeTs, $apkPackageName, $score, $action)
     {
         $response = Response::fromJson($json);
         $this->assertEquals($success, $response->isSuccess());
         $this->assertEquals($errorCodes, $response->getErrorCodes());
-        $this->assertEquals($hostname ?? '', $response->getHostname());
-        $this->assertEquals($challengeTs ?? '', $response->getChallengeTs());
-        $this->assertEquals($apkPackageName ?? '', $response->getApkPackageName());
+        $this->assertEquals($hostname, $response->getHostname());
+        $this->assertEquals($challengeTs, $response->getChallengeTs());
+        $this->assertEquals($apkPackageName, $response->getApkPackageName());
         $this->assertEquals($score, $response->getScore());
-        $this->assertEquals($action ?? '', $response->getAction());
+        $this->assertEquals($action, $response->getAction());
     }
 
-    /**
-     * @return array<int, array{0: string, 1: bool, 2: array<string>, 3: null|string, 4: null|string, 5: null|string, 6: null|float, 7: null|string}>
-     */
-    public static function provideJson(): array
+    public static function provideJson()
     {
         return [
             [
@@ -111,22 +103,10 @@ class ResponseTest extends TestCase
                 'BAD JSON',
                 false, [ReCaptcha::E_INVALID_JSON], null, null, null, null, null,
             ],
-            [
-                '{"success": false, "error-codes": "invalid-input-secret"}',
-                false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
-            ],
-            [
-                '{"success": false, "error-codes": null}',
-                false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
-            ],
-            [
-                '{"success": false, "error-codes": 123}',
-                false, [ReCaptcha::E_UNKNOWN_ERROR], null, null, null, null, null,
-            ],
         ];
     }
 
-    public function testIsSuccess(): void
+    public function testIsSuccess()
     {
         $response = new Response(true);
         $this->assertTrue($response->isSuccess());
@@ -135,17 +115,17 @@ class ResponseTest extends TestCase
         $this->assertFalse($response->isSuccess());
 
         $response = new Response(true, [], 'example.com');
-        $this->assertEquals('example.com', $response->getHostname());
+        $this->assertEquals('example.com', $response->getHostName());
     }
 
-    public function testGetErrorCodes(): void
+    public function testGetErrorCodes()
     {
         $errorCodes = ['test'];
         $response = new Response(true, $errorCodes);
         $this->assertEquals($errorCodes, $response->getErrorCodes());
     }
 
-    public function testGetHostname(): void
+    public function testGetHostname()
     {
         $hostname = 'google.com';
         $errorCodes = [];
@@ -153,37 +133,38 @@ class ResponseTest extends TestCase
         $this->assertEquals($hostname, $response->getHostname());
     }
 
-    public function testGetChallengeTs(): void
+    public function testGetChallengeTs()
     {
         $timestamp = 'timestamp';
+        $errorCodes = [];
         $response = new Response(true, [], 'hostname', $timestamp);
         $this->assertEquals($timestamp, $response->getChallengeTs());
     }
 
-    public function testGetApkPackageName(): void
+    public function TestGetApkPackageName()
     {
         $apk = 'apk';
         $response = new Response(true, [], 'hostname', 'timestamp', 'apk');
         $this->assertEquals($apk, $response->getApkPackageName());
     }
 
-    public function testGetScore(): void
+    public function testGetScore()
     {
         $score = 0.5;
         $response = new Response(true, [], 'hostname', 'timestamp', 'apk', $score);
         $this->assertEquals($score, $response->getScore());
     }
 
-    public function testGetAction(): void
+    public function testGetAction()
     {
         $action = 'homepage';
-        $response = new Response(true, [], 'hostname', 'timestamp', 'apk', 0.5, 'homepage');
+        $response = new Response(true, [], 'hostname', 'timestamp', 'apk', '0.5', 'homepage');
         $this->assertEquals($action, $response->getAction());
     }
 
-    public function testToArray(): void
+    public function testToArray()
     {
-        $response = new Response(true, [], 'hostname', 'timestamp', 'apk', 0.5, 'homepage');
+        $response = new Response(true, [], 'hostname', 'timestamp', 'apk', '0.5', 'homepage');
         $expected = [
             'success' => true,
             'error-codes' => [],


### PR DESCRIPTION
1.5.0 shipped several BC breaks in a minor release without anyone noticing until after the tag (#628). This adds[Roave/BackwardCompatibilityCheck](https://github.com/Roave/BackwardCompatibilityCheck) as a CI job so that this class of mistake fails the build instead of reaching a release. As suggested in review, this is more robust than adding unit tests for specific bits of BC.

It runs as its own job and compares against the most recent release tag, so the checkout needs the full history rather than a shallow clone. It is added as a container action rather than a dev dependency, to keep it out of the project's own dependency resolution.

One ordering note: this is only useful once the restored API has been tagged. Until then, the most recent tag is 1.5.0, and the check would correctly flag the deliberate revert in the previous PR as a break.

Props to @acoulton